### PR TITLE
Add support to clear the deploy directory when finished/failed

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,6 +51,7 @@ workflows:
         - notify_user_groups: $NOTIFY_USER_GROUPS
         - notify_email_list: $NOTIFY_EMAIL_LIST
         - is_enable_public_page: "true"
+        - clear_directory: "true"
     - path::./:
         title: IOS Test compressed with default name
         run_if: true

--- a/step.yml
+++ b/step.yml
@@ -146,6 +146,18 @@ inputs:
       is_required: true
       is_dont_change_value: true
       is_sensitive: true
+  - clear_directory: "false"
+    opts:
+      title: Clear the dirctory when finished?
+      description: |-
+        If this option is allowed, the artifacts
+        found in the *Deploy directory* folder will be removed
+        when the deploy is finished.
+      is_required: false
+      is_expand: false
+      value_options:
+        - "true"
+        - "false"
 outputs:
   - BITRISE_PUBLIC_INSTALL_PAGE_URL:
     opts:


### PR DESCRIPTION
Add option that will clear the directory when the deploy is finished or failed.
This way when you have multiple deploys you can still use the same directory.

Because if you archive 3 times and deploy 3 times. The old items are still in that directory.
I could change the folder for every archive. But I like this handy flag.