### PR TITLE
Fix uploads of zero-byte files

### DIFF
--- a/uploaders/common.go
+++ b/uploaders/common.go
@@ -139,6 +139,15 @@ func uploadArtifact(uploadURL, artifactPth, contentType string) error {
 		}
 		request.ContentLength = fileInfo.Size()
 
+		// The go http library will switch the TransferEncoding to 'chunked' if
+		// it sees a Content-Length of 0 and a TransferEncoding
+		// hasn't been set to "identity", but AWS doesn't support the 'chunked'
+		// TransferEncoding!
+		// https://github.com/golang/go/blob/141b09726dcfc1fa9f04ee9e08e6fa4af00fa57b/src/net/http/request.go#L520
+		if request.ContentLength == 0 {
+			request.TransferEncoding = []string{"identity"}
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 		request = request.WithContext(ctx)


### PR DESCRIPTION
Fixes: Issue #102 

The Go http library sets the TransferEncoding to `"chunked"` if it sees a request that has a ContentLength of zero with a Body set (which is exactly what happens in `uploadArtifact`). 

This PR forces the TransferEncoding to `identity` when the file size is `0` so that this doesn't happen (as documented in the Go library code). 