### PR TITLE
Tool 1017 fix aab public install page

### DIFF
--- a/main.go
+++ b/main.go
@@ -321,15 +321,6 @@ func deploy(clearedFilesToDeploy []string, config Config) (map[string]string, er
 				config.NotifyUserGroups, config.NotifyEmailList, config.IsPublicPageEnabled); err != nil {
 				return nil, fmt.Errorf("deploy failed, error: %s", err)
 			}
-
-			// universalAPKPair, ok := aabAPKPairs[pth]
-			// if !ok {
-			// 	return nil, fmt.Errorf("no iniversal apk pair found for aab: %s", pth)
-			// }
-
-			// if universalAPKInstallPage := apkInstallPages[filepath.Base(universalAPKPair)]; universalAPKInstallPage != "" {
-			// 	publicInstallPages[filepath.Base(pth)] = universalAPKInstallPage
-			// }
 		case zippedXcarchiveExt:
 			log.Donef("Uploading xcarchive file: %s", pth)
 			if err := uploaders.DeployXcarchive(pth, config.BuildURL, config.APIToken); err != nil {

--- a/main.go
+++ b/main.go
@@ -322,14 +322,14 @@ func deploy(clearedFilesToDeploy []string, config Config) (map[string]string, er
 				return nil, fmt.Errorf("deploy failed, error: %s", err)
 			}
 
-			universalAPKPair, ok := aabAPKPairs[pth]
-			if !ok {
-				return nil, fmt.Errorf("no iniversal apk pair found for aab: %s", pth)
-			}
+			// universalAPKPair, ok := aabAPKPairs[pth]
+			// if !ok {
+			// 	return nil, fmt.Errorf("no iniversal apk pair found for aab: %s", pth)
+			// }
 
-			if universalAPKInstallPage := apkInstallPages[filepath.Base(universalAPKPair)]; universalAPKInstallPage != "" {
-				publicInstallPages[filepath.Base(pth)] = universalAPKInstallPage
-			}
+			// if universalAPKInstallPage := apkInstallPages[filepath.Base(universalAPKPair)]; universalAPKInstallPage != "" {
+			// 	publicInstallPages[filepath.Base(pth)] = universalAPKInstallPage
+			// }
 		case zippedXcarchiveExt:
 			log.Donef("Uploading xcarchive file: %s", pth)
 			if err := uploaders.DeployXcarchive(pth, config.BuildURL, config.APIToken); err != nil {

--- a/main.go
+++ b/main.go
@@ -275,7 +275,7 @@ func findAPKsAndAABs(pths []string) (apks []string, aabs []string, others []stri
 
 func deploy(clearedFilesToDeploy []string, config Config) (map[string]string, error) {
 	apks, aabs, others := findAPKsAndAABs(clearedFilesToDeploy)
-	apks, aabAPKPairs, err := ensureAABsHasUniversalAPKPair(aabs, apks)
+	apks, _, err := ensureAABsHasUniversalAPKPair(aabs, apks)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func deploy(clearedFilesToDeploy []string, config Config) (map[string]string, er
 			log.Donef("Uploading aab file: %s", pth)
 
 			if err := uploaders.DeployAAB(pth, androidArtifacts, config.BuildURL, config.APIToken,
-				config.NotifyUserGroups, config.NotifyEmailList, "false"); err != nil {
+				config.NotifyUserGroups, config.NotifyEmailList, config.IsPublicPageEnabled); err != nil {
 				return nil, fmt.Errorf("deploy failed, error: %s", err)
 			}
 

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func deploy(clearedFilesToDeploy []string, config Config) (map[string]string, er
 			log.Donef("Uploading aab file: %s", pth)
 
 			if err := uploaders.DeployAAB(pth, androidArtifacts, config.BuildURL, config.APIToken,
-				config.NotifyUserGroups, config.NotifyEmailList, config.IsPublicPageEnabled); err != nil {
+				config.NotifyUserGroups, config.NotifyEmailList, "false"); err != nil {
 				return nil, fmt.Errorf("deploy failed, error: %s", err)
 			}
 

--- a/uploaders/utils.go
+++ b/uploaders/utils.go
@@ -22,7 +22,7 @@ func fileSizeInBytes(pth string) (float64, error) {
 		return 0, err
 	}
 	if !exist {
-		return 0, fmt.Errorf("file not exist, error: %s", err)
+		return 0, fmt.Errorf("file not exist")
 	}
 
 	bytes := float64(info.Size())


### PR DESCRIPTION
Originally the bug was:
"The `BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP` variable contains the `.aab` file's name with the generated `universal.apk`'s Public Install Page"

---

But as the AAB artifact does not have a public install page I removed it from the `BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP` as well. 