### PR TITLE
Change bundletool version to 0.12.0

### DIFF
--- a/bundletool/bundletool.go
+++ b/bundletool/bundletool.go
@@ -14,7 +14,7 @@ type Path string
 
 // New ...
 func New() (Path, error) {
-	const downloadURL = "https://github.com/google/bundletool/releases/download/0.9.0/bundletool-all-0.9.0.jar"
+	const downloadURL = "https://github.com/google/bundletool/releases/download/0.12.0/bundletool-all-0.12.0.jar"
 
 	tmpPth, err := pathutil.NormalizedOSTempDirPath("tool")
 	if err != nil {


### PR DESCRIPTION
Customer is asking for bundletool to be upgraded because of a bug (more details here: https://github.com/google/bundletool/issues/113) preventing users from bundling the universal APKs from .aab.

This was fixed in version 0.10.3 but 0.12.0 is out, I am requesting upgrading from 0.9.0 to 0.12.0.

#114 