### PR TITLE
Added support for the "message" attribute of "Failure" for jUnit pars…

### DIFF
--- a/test/converters/converters_test.go
+++ b/test/converters/converters_test.go
@@ -57,7 +57,9 @@ func TestXCresult3Converters(t *testing.T) {
 						Name:      "testFailMe",
 						ClassName: "_TtCC17rtgtrghtrgUITests17rtgtrghtrgUITests18rtgtrghtrg3UITests",
 						Time:      0.09049093723297119,
-						Failure:   "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=67&StartingLineNumber=67 - XCTAssertTrue failed",
+						Failure: &junit.Failure{
+							Value: "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=67&StartingLineNumber=67 - XCTAssertTrue failed",
+						},
 					},
 					{
 						Name:      "testLaunchPerformance",
@@ -75,7 +77,9 @@ func TestXCresult3Converters(t *testing.T) {
 						Name:      "testFailMe()",
 						ClassName: "rtgtrghtrg2UITests",
 						Time:      0.08525991439819336,
-						Failure:   "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=104&StartingLineNumber=104 - XCTAssertTrue failed",
+						Failure: &junit.Failure{
+							Value: "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=104&StartingLineNumber=104 - XCTAssertTrue failed",
+						},
 					},
 					{
 						Name:      "testLaunchPerformance()",
@@ -103,7 +107,9 @@ func TestXCresult3Converters(t *testing.T) {
 						Name:      "testFailMe2()",
 						ClassName: "rtgtrghtrg4UITests",
 						Time:      0.08395206928253174,
-						Failure:   "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=129&StartingLineNumber=129 - XCTAssertTrue failed",
+						Failure: &junit.Failure{
+							Value: "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=129&StartingLineNumber=129 - XCTAssertTrue failed",
+						},
 					},
 					{
 						Name:      "testLaunchPerformance()",

--- a/test/converters/junitxml/junitxml.go
+++ b/test/converters/junitxml/junitxml.go
@@ -22,6 +22,7 @@ func (h *Converter) Detect(files []string) bool {
 			h.files = append(h.files, file)
 		}
 	}
+
 	return len(h.files) > 0
 }
 
@@ -34,8 +35,14 @@ func regroupErrors(suites []junit.TestSuite) []junit.TestSuite {
 		for testCaseIndex, tc := range suite.TestCases {
 			var messages []string
 
-			if len(tc.Failure) > 0 {
-				messages = append(messages, tc.Failure)
+			if tc.Failure != nil {
+				if len(tc.Failure.Message) > 0 {
+					messages = append(messages, tc.Failure.Message)
+				}
+
+				if len(tc.Failure.Value) > 0 {
+					messages = append(messages, tc.Failure.Value)
+				}
 			}
 
 			if tc.Error != nil {
@@ -52,13 +59,19 @@ func regroupErrors(suites []junit.TestSuite) []junit.TestSuite {
 				messages = append(messages, "System error:\n"+tc.SystemErr)
 			}
 
-			tc.Failure, tc.Error, tc.SystemErr = strings.Join(messages, "\n\n"), nil, ""
+			tc.Error, tc.SystemErr = nil, ""
+			if messages != nil {
+				tc.Failure = &junit.Failure{
+					Value: strings.Join(messages, "\n\n"),
+				}
+			}
 
 			suites[testSuiteIndex].Failures += suites[testSuiteIndex].Errors
 			suites[testSuiteIndex].Errors = 0
 			suites[testSuiteIndex].TestCases[testCaseIndex] = tc
 		}
 	}
+
 	return suites
 }
 

--- a/test/converters/junitxml/junitxml.go
+++ b/test/converters/junitxml/junitxml.go
@@ -9,25 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type resultReader interface {
-	ReadAll() ([]byte, error)
-}
-
-type fileReader struct {
-	Filename string
-}
-
-func (r *fileReader) ReadAll() ([]byte, error) {
-	return ioutil.ReadFile(r.Filename)
-}
-
-type stringReader struct {
-	Contents string
-}
-
-func (r *stringReader) ReadAll() ([]byte, error) {
-	return []byte(r.Contents), nil
-}
+type resultReader func() ([]byte, error)
 
 // Converter holds data of the converter
 type Converter struct {
@@ -39,7 +21,9 @@ func (h *Converter) Detect(files []string) bool {
 	h.results = nil
 	for _, file := range files {
 		if strings.HasSuffix(file, ".xml") {
-			h.results = append(h.results, &fileReader{Filename: file})
+			h.results = append(h.results, func() ([]byte, error) {
+				return ioutil.ReadFile(file)
+			})
 		}
 	}
 
@@ -95,8 +79,8 @@ func regroupErrors(suites []junit.TestSuite) []junit.TestSuite {
 	return suites
 }
 
-func parseTestSuites(result resultReader) ([]junit.TestSuite, error) {
-	data, err := result.ReadAll()
+func parseTestSuites(readResult resultReader) ([]junit.TestSuite, error) {
+	data, err := readResult()
 	if err != nil {
 		return nil, err
 	}

--- a/test/converters/junitxml/junitxml_test.go
+++ b/test/converters/junitxml/junitxml_test.go
@@ -33,152 +33,265 @@ func Test_regroupErrors(t *testing.T) {
 		suites []junit.TestSuite
 		want   []junit.TestSuite
 	}{
-		{"regroup error message", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Error: &junit.Error{Message: "error message"}},
-			}},
+		{
+			name: "regroup error message",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Error: &junit.Error{
+						Message: "error message",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "Error message:\nerror message",
+					},
+				},
+			}}},
 		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "Error message:\nerror message"},
-				}},
-			},
+		{
+			name: "regroup error body",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Error: &junit.Error{
+						Value: "error message",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "Error value:\nerror message",
+					},
+				},
+			}}},
 		},
-
-		{"regroup error body", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Error: &junit.Error{Value: "error message"}},
-			}},
-		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "Error value:\nerror message"},
-				}},
-			},
-		},
-
-		{"regroup system err", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{SystemErr: "error message"},
-			}},
-		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "System error:\nerror message"},
-				}},
-			},
-		},
-
-		{"regroup error message - multiple test cases", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Error: &junit.Error{Message: "error message"}},
-				{Error: &junit.Error{Message: "error message2"}},
-			}},
-		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "Error message:\nerror message"},
-					{Failure: "Error message:\nerror message2"},
-				}},
-			},
-		},
-
-		{"regroup error body - multiple test cases", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Error: &junit.Error{Value: "error message"}},
-				{Error: &junit.Error{Value: "error message2"}},
-			}},
-		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "Error value:\nerror message"},
-					{Failure: "Error value:\nerror message2"},
-				}},
-			},
+		{
+			name: "regroup system err",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					SystemErr: "error message",
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "System error:\nerror message",
+					},
+				},
+			}}},
 		},
 
-		{"regroup system err - multiple test cases", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{SystemErr: "error message"},
-				{SystemErr: "error message2"},
-			}},
+		{
+			name: "regroup error message - multiple test cases",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Error: &junit.Error{
+						Message: "error message",
+					},
+				},
+				{
+					Error: &junit.Error{
+						Message: "error message2",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "Error message:\nerror message",
+					},
+				},
+				{
+					Failure: &junit.Failure{
+						Value: "Error message:\nerror message2",
+					},
+				},
+			}}},
 		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "System error:\nerror message"},
-					{Failure: "System error:\nerror message2"},
-				}},
-			},
+		{
+			name: "regroup error body - multiple test cases",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Error: &junit.Error{
+						Value: "error message",
+					},
+				},
+				{
+					Error: &junit.Error{
+						Value: "error message2",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "Error value:\nerror message",
+					},
+				},
+				{
+					Failure: &junit.Failure{
+						Value: "Error value:\nerror message2",
+					},
+				},
+			}}},
 		},
-
-		{"should not touch failure", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Failure: "error message"},
-			}},
+		{
+			name: "regroup system err - multiple test cases",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					SystemErr: "error message",
+				},
+				{
+					SystemErr: "error message2",
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "System error:\nerror message",
+					},
+				},
+				{
+					Failure: &junit.Failure{
+						Value: "System error:\nerror message2",
+					},
+				},
+			}}},
 		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "error message"},
-				}},
-			},
+		{
+			name: "should not touch failure",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "error message",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "error message",
+					},
+				},
+			}}},
 		},
-
-		{"should append error body to failure", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Failure: "failure message", Error: &junit.Error{Value: "error value"}},
-			}},
+		{
+			name: "should append error body to failure",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message",
+					},
+					Error: &junit.Error{
+						Value: "error value",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message\n\nError value:\nerror value",
+					},
+				},
+			}}},
 		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "failure message\n\nError value:\nerror value"},
-				}},
-			},
+		{
+			name: "should append error message to failure",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "Failure message",
+					},
+					Error: &junit.Error{
+						Message: "error value",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "Failure message\n\nError message:\nerror value",
+					},
+				},
+			}}},
 		},
-
-		{"should append error message to failure", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Failure: "failure message", Error: &junit.Error{Message: "error value"}},
-			}},
+		{
+			name: "should append system error to failure",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message",
+					},
+					SystemErr: "error value",
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message\n\nSystem error:\nerror value",
+					},
+				},
+			}}},
 		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "failure message\n\nError message:\nerror value"},
-				}},
-			},
+		{
+			name: "should append system error, error message, error body to failure",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message",
+					},
+					SystemErr: "error value",
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message\n\nSystem error:\nerror value",
+					},
+				},
+			}}},
 		},
-
-		{"should append system error to failure", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Failure: "failure message", SystemErr: "error value"},
-			}},
+		{
+			name: "should append system error, error message, error body to failure",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Message: "failure message",
+						Value:   "failure content",
+					},
+					SystemErr: "error value",
+					Error: &junit.Error{
+						Message: "message",
+						Value:   "value",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "failure message\n\nfailure content\n\nError message:\nmessage\n\nError value:\nvalue\n\nSystem error:\nerror value",
+					},
+				},
+			}}},
 		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "failure message\n\nSystem error:\nerror value"},
-				}},
-			},
-		},
-		{"should append system error, error message, error body to failure", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Failure: "failure message", SystemErr: "error value"},
-			}},
-		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "failure message\n\nSystem error:\nerror value"},
-				}},
-			},
-		},
-		{"should append system error, error message, error body to failure", []junit.TestSuite{
-			{TestCases: []junit.TestCase{
-				{Failure: "failure message", SystemErr: "error value", Error: &junit.Error{Message: "message", Value: "value"}},
-			}},
-		},
-			[]junit.TestSuite{
-				{TestCases: []junit.TestCase{
-					{Failure: "failure message\n\nError message:\nmessage\n\nError value:\nvalue\n\nSystem error:\nerror value"},
-				}},
-			},
+		{
+			name: "Should convert Message attribute of Failure element to the value of a Failure element",
+			suites: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Message: "ErrorMsg",
+					},
+				},
+			}}},
+			want: []junit.TestSuite{{TestCases: []junit.TestCase{
+				{
+					Failure: &junit.Failure{
+						Value: "ErrorMsg",
+					},
+				},
+			}}},
 		},
 	}
 	for _, tt := range tests {

--- a/test/converters/junitxml/junitxml_test.go
+++ b/test/converters/junitxml/junitxml_test.go
@@ -2,7 +2,6 @@ package junitxml
 
 import (
 	"encoding/xml"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -21,9 +20,7 @@ func Test_parseTestSuites(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parseTestSuites(func() ([]byte, error) {
-				return ioutil.ReadFile(tt.path)
-			})
+			_, err := parseTestSuites(&fileReader{Filename: tt.path})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseTestSuites() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -311,13 +308,14 @@ func Test_regroupErrors(t *testing.T) {
 func TestConverter_XML(t *testing.T) {
 	tests := []struct {
 		name    string
-		results []string
+		results []resultReader
 		want    junit.XML
 		wantErr bool
 	}{
 		{
 			name: "Error message in Message atttribute of Failure element",
-			results: []string{`<?xml version="1.0" encoding="UTF-8"?>
+			results: []resultReader{&stringReader{
+				Contents: `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="2" failures="1">
 	<testsuite name="MyApp-Unit-Tests" tests="2" failures="0" time="0.398617148399353">
 		<testcase classname="PaymentContextTests" name="testPaymentSuccessShowsTooltip()" time="0.19384193420410156">
@@ -327,7 +325,8 @@ func TestConverter_XML(t *testing.T) {
 			</failure>
 		</testcase>
 	</testsuite>
-</testsuites>`},
+</testsuites>`,
+			}},
 			want: junit.XML{
 				TestSuites: []junit.TestSuite{
 					{
@@ -362,15 +361,8 @@ func TestConverter_XML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &Converter{
-				results: []resultReader{},
+				results: tt.results,
 			}
-
-			for _, result := range tt.results {
-				h.results = append(h.results, func() ([]byte, error) {
-					return []byte(result), nil
-				})
-			}
-
 			got, err := h.XML()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Converter.XML() error = %v, wantErr %v", err, tt.wantErr)

--- a/test/converters/xcresult/xcresult.go
+++ b/test/converters/xcresult/xcresult.go
@@ -85,10 +85,19 @@ func (h *Converter) XML() (junit.XML, error) {
 		}
 
 		for _, test := range tests {
+			failureMessage := test.Failure()
+
+			var failure *junit.Failure
+			if len(failureMessage) > 0 {
+				failure = &junit.Failure{
+					Value: failureMessage,
+				}
+			}
+
 			testSuite.TestCases = append(testSuite.TestCases, junit.TestCase{
 				Name:      test.TestName,
 				ClassName: testID,
-				Failure:   test.Failure(),
+				Failure:   failure,
 				Time:      test.Duration,
 			})
 		}

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -113,10 +113,19 @@ func (c *Converter) XML() (junit.XML, error) {
 					}
 				}
 
+				failureMessage := record.failure(test, testSuit)
+
+				var failure *junit.Failure
+				if len(failureMessage) > 0 {
+					failure = &junit.Failure{
+						Value: failureMessage,
+					}
+				}
+
 				testSuit.TestCases = append(testSuit.TestCases, junit.TestCase{
 					Name:      test.Name.Value,
 					ClassName: strings.Split(test.Identifier.Value, "/")[0],
-					Failure:   record.failure(test, testSuit),
+					Failure:   failure,
 					Time:      duartion,
 				})
 

--- a/test/junit/xml.go
+++ b/test/junit/xml.go
@@ -27,9 +27,16 @@ type TestCase struct {
 	Name      string   `xml:"name,attr"`
 	ClassName string   `xml:"classname,attr"`
 	Time      float64  `xml:"time,attr"`
-	Failure   string   `xml:"failure,omitempty"`
+	Failure   *Failure `xml:"failure,omitempty"`
 	Error     *Error   `xml:"error,omitempty"`
 	SystemErr string   `xml:"system-err,omitempty"`
+}
+
+// Failure ...
+type Failure struct {
+	XMLName xml.Name `xml:"failure,omitempty"`
+	Message string   `xml:"message,attr,omitempty"`
+	Value   string   `xml:",chardata"`
 }
 
 // Error ...

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -228,7 +229,7 @@ func Test_ParseTestResults(t *testing.T) {
 		}
 
 		if len(bundle[0].XMLContent) != len(sampleIOSXmlOutput) {
-			t.Fatal("wrong xml content")
+			t.Fatal(fmt.Sprintf("wrong xml content: %s", bundle[0].XMLContent))
 		}
 	}
 


### PR DESCRIPTION
…er (used for Test Results Addon)

- Added "Failure" struct, preserving the contents parser ("Value") and added "Message" property which matches the "message" attribure
- The "message" attribute contents is appended to the TestCase Failure contents, similarly as done for the "error" and "system-err" XML subelements.
- Fixed references to the "Failure" field