### PR TITLE
Change bundletool version to 0.13.4

### DIFF
--- a/bundletool/bundletool.go
+++ b/bundletool/bundletool.go
@@ -14,7 +14,7 @@ type Path string
 
 // New ...
 func New() (Path, error) {
-	const downloadURL = "https://github.com/google/bundletool/releases/download/0.12.0/bundletool-all-0.12.0.jar"
+	const downloadURL = "https://github.com/google/bundletool/releases/download/0.13.4/bundletool-all.jar"
 
 	tmpPth, err := pathutil.NormalizedOSTempDirPath("tool")
 	if err != nil {


### PR DESCRIPTION
After upgrading from Android Gradle Plugin 3.5.X to 3.6.X, I'm running into the same issue as #114. 

> Error: Program type already present: $r8$backportedMethods$utility$Long$1$hashCode
[BT:0.12.0] Error: Dex merging failed.

Our Bitrise build is already using bundletool 0.12.0. Upgrading to the latest version (currently 0.13.4) resolves the issue. Is it possible to merge this PR to upgrade to that version?

In the mean time I'll fork the repo to triage the issue until bundletool has been upgraded.