### PR TITLE
Propose the deprecation of universal APK generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -336,7 +336,7 @@ func deploy(clearedFilesToDeploy []string, config Config) (ArtifactURLCollection
 	apks, aabs, others := findAPKsAndAABs(clearedFilesToDeploy)
 
 	log.Warnf(`Universal APK generation is going to be DEPRECATED with the next major release! In case you build a bundle and you would like to
-export a universal APK, please use the Export Universal APK Step instead!
+export a universal APK to distribute it for testing (by Public install page or Ship Add-on), please use the Export Universal APK Step instead!
 You may find further information about the Step here (https://devcenter.bitrise.io/deploy/android-deploy/exporting-a-universal-apk-from-an-aab/).`)
 
 	if config.GenerateUniversalApkIfNone {

--- a/main.go
+++ b/main.go
@@ -335,7 +335,8 @@ func findAPKsAndAABs(pths []string) (apks []string, aabs []string, others []stri
 func deploy(clearedFilesToDeploy []string, config Config) (ArtifactURLCollection, error) {
 	apks, aabs, others := findAPKsAndAABs(clearedFilesToDeploy)
 
-	log.Warnf(`Universal APK generation is going to be DEPRECATED with the next major release! Please use the Export Universal APK Step instead!
+	log.Warnf(`Universal APK generation is going to be DEPRECATED with the next major release! In case you build a bundle and you would like to
+export a universal APK, please use the Export Universal APK Step instead!
 You may find further information about the Step here (https://devcenter.bitrise.io/deploy/android-deploy/exporting-a-universal-apk-from-an-aab/).`)
 
 	if config.GenerateUniversalApkIfNone {

--- a/main.go
+++ b/main.go
@@ -335,6 +335,9 @@ func findAPKsAndAABs(pths []string) (apks []string, aabs []string, others []stri
 func deploy(clearedFilesToDeploy []string, config Config) (ArtifactURLCollection, error) {
 	apks, aabs, others := findAPKsAndAABs(clearedFilesToDeploy)
 
+	log.Warnf(`Universal APK generation is going to be DEPRECATED with the next major release! Please use the Export Universal APK Step instead!
+You may find further information about the Step here (https://devcenter.bitrise.io/deploy/android-deploy/exporting-a-universal-apk-from-an-aab/).`)
+
 	if config.GenerateUniversalApkIfNone {
 		var err error
 		apks, _, err = ensureAABsHasUniversalAPKPair(aabs, apks, config.BundletoolVersion)

--- a/step.yml
+++ b/step.yml
@@ -225,7 +225,7 @@ inputs:
       is_sensitive: true
   - generate_universal_apk_if_none: "true"
     opts:
-      title: "Force generate universal APK for AABs"
+      title: "Force generate universal APK for AABs (DEPRECATED)"
       description: |
         Universal APK generation is going to be  **DEPRECATED** with the next
         major release! Please use the _Export Universal APK_ Step instead! You 

--- a/step.yml
+++ b/step.yml
@@ -227,6 +227,10 @@ inputs:
     opts:
       title: "Force generate universal APK for AABs"
       description: |
+        Universal APK generation is going to be  **DEPRECATED** with the next
+        major release! Please use the _Export Universal APK_ Step instead! You 
+        may find further information about the Step [here](https://devcenter.bitrise.io/deploy/android-deploy/exporting-a-universal-apk-from-an-aab/).
+
         When building an AAB artifact, check for a corresponding universal APK.
         If none is found, generate the corresponding locally (debug) signed
         universal APK for ease of debugging.

--- a/step.yml
+++ b/step.yml
@@ -227,13 +227,13 @@ inputs:
     opts:
       title: "Force generate universal APK for AABs (DEPRECATED)"
       description: |
-        Universal APK generation is going to be  **DEPRECATED** with the next
-        major release! Please use the _Export Universal APK_ Step instead! You 
-        may find further information about the Step [here](https://devcenter.bitrise.io/deploy/android-deploy/exporting-a-universal-apk-from-an-aab/).
+        Universal APK generation is scheduled to be **DEPRECATED** in the next
+        major release. Please use the **Export Universal APK** Step instead! You 
+        may find further information about the Step in our [Exporting a universal APK from an AAB](https://devcenter.bitrise.io/deploy/android-deploy/exporting-a-universal-apk-from-an-aab/) article.
 
         When building an AAB artifact, check for a corresponding universal APK.
         If none is found, generate the corresponding locally (debug) signed
-        universal APK for ease of debugging.
+        universal APK for easier debugging.
   - debug_mode: "false"
     opts: 
       category: Debug


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context
We are going to deprecate the universal APK generation capability of this Step, in favor of the _Export Universal APK_ Step.
As a first step, a deprecation note is added indicating the process for the Customers. We will completely remove the capability with the next major release.

### Changes
- A deprecation note is added to the description of the input.
- A warning message is added to the deployment logic.

### Investigation details

The depreciation is supported by [this](https://bitrise.atlassian.net/wiki/spaces/STEP/pages/1168048427/Investigate+universal+APK+exporting) investigation.
