### PR TITLE
Fix broken Markdown links

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -161,7 +161,7 @@ inputs:
       title: Format for the BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP output
       summary: You can customize the format of the `BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP` output so that the next Step can render the output.
       description: |-
-        Provide a language template description using [https://golang.org/pkg/text/template]([https://golang.org/pkg/text/template)
+        Provide a language template description using [Golang templates](https://golang.org/pkg/text/template)
         so that the **Deploy to Bitrise.io** Step can build the required custom output.
       is_required: true
       is_expand: false
@@ -170,7 +170,7 @@ inputs:
       title: Format for the BITRISE_PERMANENT_DOWNLOAD_URL_MAP output
       summary: You can customize the format of the `BITRISE_PERMANENT_DOWNLOAD_URL_MAP` output so that the next Step can render the output.
       description: |-
-        Provide a language template description using [https://golang.org/pkg/text/template]([https://golang.org/pkg/text/template)
+        Provide a language template description using [Golang templates](https://golang.org/pkg/text/template)
         so that the **Deploy to Bitrise.io** Step can build the required custom output for the permanent download URL.  
       is_required: true
       is_expand: false


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

<!--- One sentence summary on why the change is needed. -->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
