### PR TITLE
[BINS-319] junit report generation fix when report includes a flaky rerun

### DIFF
--- a/test/converters/converters_test.go
+++ b/test/converters/converters_test.go
@@ -58,7 +58,7 @@ func TestXCresult3Converters(t *testing.T) {
 						ClassName: "_TtCC17rtgtrghtrgUITests17rtgtrghtrgUITests18rtgtrghtrg3UITests",
 						Time:      0.09049093723297119,
 						Failure: &junit.Failure{
-							Value: "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=67&StartingLineNumber=67 - XCTAssertTrue failed",
+							Value: "/Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:68 - XCTAssertTrue failed",
 						},
 					},
 					{
@@ -78,7 +78,7 @@ func TestXCresult3Converters(t *testing.T) {
 						ClassName: "rtgtrghtrg2UITests",
 						Time:      0.08525991439819336,
 						Failure: &junit.Failure{
-							Value: "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=104&StartingLineNumber=104 - XCTAssertTrue failed",
+							Value: "/Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:105 - XCTAssertTrue failed",
 						},
 					},
 					{
@@ -108,7 +108,7 @@ func TestXCresult3Converters(t *testing.T) {
 						ClassName: "rtgtrghtrg4UITests",
 						Time:      0.08395206928253174,
 						Failure: &junit.Failure{
-							Value: "file:///Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:CharacterRangeLen=0&EndingLineNumber=129&StartingLineNumber=129 - XCTAssertTrue failed",
+							Value: "/Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:130 - XCTAssertTrue failed",
 						},
 					},
 					{

--- a/test/converters/xcresult/testsummariesplist.go
+++ b/test/converters/xcresult/testsummariesplist.go
@@ -24,7 +24,8 @@ func collapseSubtestTree(data Subtests) (tests Subtests) {
 }
 
 // Tests returns the collapsed tree of tests
-func (summaryPlist TestSummaryPlist) Tests() map[string]Subtests {
+func (summaryPlist TestSummaryPlist) Tests() ([]string, map[string]Subtests) {
+	keyOrder := []string{}
 	tests := map[string]Subtests{}
 	var subTests Subtests
 	for _, testableSummary := range summaryPlist.TestableSummaries {
@@ -35,9 +36,12 @@ func (summaryPlist TestSummaryPlist) Tests() map[string]Subtests {
 	for _, test := range subTests {
 		// TestIdentifier is in a format of testID/testCase
 		testID := strings.Split(test.TestIdentifier, "/")[0]
+		if _, found := tests[testID]; !found {
+			keyOrder = append(keyOrder, testID)
+		}
 		tests[testID] = append(tests[testID], test)
 	}
-	return tests
+	return keyOrder, tests
 }
 
 // Test ...

--- a/test/converters/xcresult/testsummariesplist.go
+++ b/test/converters/xcresult/testsummariesplist.go
@@ -25,7 +25,7 @@ func collapseSubtestTree(data Subtests) (tests Subtests) {
 
 // Tests returns the collapsed tree of tests
 func (summaryPlist TestSummaryPlist) Tests() ([]string, map[string]Subtests) {
-	keyOrder := []string{}
+	var keyOrder []string
 	tests := map[string]Subtests{}
 	var subTests Subtests
 	for _, testableSummary := range summaryPlist.TestableSummaries {

--- a/test/converters/xcresult/xcresult.go
+++ b/test/converters/xcresult/xcresult.go
@@ -76,7 +76,9 @@ func (h *Converter) XML() (junit.XML, error) {
 	}
 
 	var xmlData junit.XML
-	for testID, tests := range plistData.Tests() {
+	keyOrder, tests := plistData.Tests()
+	for _, testID := range keyOrder {
+		tests := tests[testID]
 		testSuite := junit.TestSuite{
 			Name:     testID,
 			Tests:    len(tests),

--- a/test/converters/xcresult3/action_test_plan_summary.go
+++ b/test/converters/xcresult3/action_test_plan_summary.go
@@ -42,11 +42,14 @@ type Name struct {
 func (s ActionTestPlanRunSummaries) tests() ([]string, map[string][]ActionTestSummaryGroup) {
 	summaryGroupsByName := map[string][]ActionTestSummaryGroup{}
 
-	testSuiteOrdering := []string{}
+	var testSuiteOrder []string
 	for _, summary := range s.Summaries.Values {
 		for _, testableSummary := range summary.TestableSummaries.Values {
 			// test suit
 			name := testableSummary.Name.Value
+			if _, found := summaryGroupsByName[name]; !found {
+				testSuiteOrder = append(testSuiteOrder, name)
+			}
 
 			var tests []ActionTestSummaryGroup
 			for _, test := range testableSummary.Tests.Values {
@@ -54,11 +57,10 @@ func (s ActionTestPlanRunSummaries) tests() ([]string, map[string][]ActionTestSu
 			}
 
 			summaryGroupsByName[name] = tests
-			testSuiteOrdering = append(testSuiteOrdering, name)
 		}
 	}
 
-	return testSuiteOrdering, summaryGroupsByName
+	return testSuiteOrder, summaryGroupsByName
 }
 
 func (s ActionTestPlanRunSummaries) failuresCount(testableSummaryName string) (failure int) {

--- a/test/converters/xcresult3/action_test_plan_summary.go
+++ b/test/converters/xcresult3/action_test_plan_summary.go
@@ -39,9 +39,10 @@ type Name struct {
 }
 
 // tests returns ActionTestSummaryGroup mapped by the container TestableSummary name.
-func (s ActionTestPlanRunSummaries) tests() map[string][]ActionTestSummaryGroup {
+func (s ActionTestPlanRunSummaries) tests() ([]string, map[string][]ActionTestSummaryGroup) {
 	summaryGroupsByName := map[string][]ActionTestSummaryGroup{}
 
+	testSuiteOrdering := []string{}
 	for _, summary := range s.Summaries.Values {
 		for _, testableSummary := range summary.TestableSummaries.Values {
 			// test suit
@@ -53,14 +54,15 @@ func (s ActionTestPlanRunSummaries) tests() map[string][]ActionTestSummaryGroup 
 			}
 
 			summaryGroupsByName[name] = tests
+			testSuiteOrdering = append(testSuiteOrdering, name)
 		}
 	}
 
-	return summaryGroupsByName
+	return testSuiteOrdering, summaryGroupsByName
 }
 
 func (s ActionTestPlanRunSummaries) failuresCount(testableSummaryName string) (failure int) {
-	testsByCase := s.tests()
+	_, testsByCase := s.tests()
 	tests := testsByCase[testableSummaryName]
 	for _, test := range tests {
 		if test.TestStatus.Value == "Failure" {
@@ -71,7 +73,7 @@ func (s ActionTestPlanRunSummaries) failuresCount(testableSummaryName string) (f
 }
 
 func (s ActionTestPlanRunSummaries) skippedCount(testableSummaryName string) (skipped int) {
-	testsByCase := s.tests()
+	_, testsByCase := s.tests()
 	tests := testsByCase[testableSummaryName]
 	for _, test := range tests {
 		if test.TestStatus.Value == "Skipped" {
@@ -82,7 +84,7 @@ func (s ActionTestPlanRunSummaries) skippedCount(testableSummaryName string) (sk
 }
 
 func (s ActionTestPlanRunSummaries) totalTime(testableSummaryName string) (time float64) {
-	testsByCase := s.tests()
+	_, testsByCase := s.tests()
 	tests := testsByCase[testableSummaryName]
 	for _, test := range tests {
 		if test.Duration.Value != "" {

--- a/test/converters/xcresult3/action_test_plan_summary_test.go
+++ b/test/converters/xcresult3/action_test_plan_summary_test.go
@@ -101,7 +101,7 @@ func TestActionTestPlanRunSummaries_tests(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.summaries.tests(); !reflect.DeepEqual(got, tt.want) {
+			if _, got := tt.summaries.tests(); !reflect.DeepEqual(got, tt.want) {
 				fmt.Println("want: ", pretty.Object(tt.want))
 				fmt.Println("got: ", pretty.Object(got))
 				t.Errorf("ActionTestPlanRunSummaries.tests() = %v, want %v", got, tt.want)

--- a/test/converters/xcresult3/action_test_summary.go
+++ b/test/converters/xcresult3/action_test_summary.go
@@ -28,7 +28,28 @@ type ActivitySummaries struct {
 	Values []ActionTestActivitySummary `json:"_values"`
 }
 
+// ActionTestFailureSummary ...
+type ActionTestFailureSummary struct {
+	Message struct {
+		Value string `json:"_value"`
+	} `json:"message"`
+
+	FileName struct {
+		Value string `json:"_value"`
+	} `json:"fileName"`
+
+	LineNumber struct {
+		Value string `json:"_value"`
+	} `json:"lineNumber"`
+}
+
+// FailureSummaries ...
+type FailureSummaries struct {
+	Values []ActionTestFailureSummary `json:"_values"`
+}
+
 // ActionTestSummary ...
 type ActionTestSummary struct {
 	ActivitySummaries ActivitySummaries `json:"activitySummaries"`
+	FailureSummaries  FailureSummaries  `json:"failureSummaries"`
 }

--- a/test/converters/xcresult3/action_test_summary_group.go
+++ b/test/converters/xcresult3/action_test_summary_group.go
@@ -1,10 +1,10 @@
 package xcresult3
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ActionTestSummaryGroup ...
@@ -73,12 +73,12 @@ func (g ActionTestSummaryGroup) testsWithStatus() (tests []ActionTestSummaryGrou
 // loadActionTestSummary ...
 func (g ActionTestSummaryGroup) loadActionTestSummary(xcresultPath string) (ActionTestSummary, error) {
 	if g.SummaryRef.ID.Value == "" {
-		return ActionTestSummary{}, errors.Errorf("no summaryRef.ID.Value found for test case")
+		return ActionTestSummary{}, errors.New("no summaryRef.ID.Value found for test case")
 	}
 
 	var summary ActionTestSummary
 	if err := xcresulttoolGet(xcresultPath, g.SummaryRef.ID.Value, &summary); err != nil {
-		return ActionTestSummary{}, errors.Wrap(err, "failed to load ActionTestSummary")
+		return ActionTestSummary{}, fmt.Errorf("failed to load ActionTestSummary: %w", err)
 	}
 	return summary, nil
 }

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -130,7 +130,10 @@ func (c *Converter) XML() (junit.XML, error) {
 						line := aTestFailureSummary.LineNumber.Value
 						message := aTestFailureSummary.Message.Value
 
-						failureMessage += fmt.Sprintf("%s:%s - %s\n", file, line, message)
+						if len(failureMessage) > 0 {
+							failureMessage += "\n"
+						}
+						failureMessage += fmt.Sprintf("%s:%s - %s", file, line, message)
 					}
 
 					failure = &junit.Failure{

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -95,9 +95,11 @@ func (c *Converter) XML() (junit.XML, error) {
 
 	var xmlData junit.XML
 	for _, summary := range summaries {
-		testsByName := summary.tests()
+		testSuiteOrder, testsByName := summary.tests()
 
-		for name, tests := range testsByName {
+		for _, name := range testSuiteOrder {
+			tests := testsByName[name]
+
 			testSuit := junit.TestSuite{
 				Name:     name,
 				Tests:    len(tests),

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -98,7 +98,7 @@ func TestConverter_XML(t *testing.T) {
 					{
 						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.1958599090576172,
 						Failure: &junit.Failure{
-							Value: "/Users/vagrant/git/BullsEyeFlakyTests/BullsEyeFlakyTests.swift:43 - XCTAssertEqual failed: (\"1\") is not equal to (\"0\") - Number is not even\n",
+							Value: "/Users/vagrant/git/BullsEyeFlakyTests/BullsEyeFlakyTests.swift:43 - XCTAssertEqual failed: (\"1\") is not equal to (\"0\") - Number is not even",
 						},
 					},
 					{
@@ -144,7 +144,7 @@ func TestConverter_XML(t *testing.T) {
 						ClassName: "testProjectUITests",
 						Time:      0.2580660581588745,
 						Failure: &junit.Failure{
-							Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed\n",
+							Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed",
 						},
 					},
 					{

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -27,6 +27,92 @@ func copyTestdataToDir(t *testing.T, pathInTestdataDir, dirPathToCopyInto string
 }
 
 func TestConverter_XML(t *testing.T) {
+	t.Run("xcresult3-flaky-with-rerun.xcresult", func(t *testing.T) {
+		// copy test data to tmp dir
+		tempTestdataDir, err := pathutil.NormalizedOSTempDirPath("test")
+		if err != nil {
+			t.Fatal("failed to create temp dir, error:", err)
+		}
+		defer func() {
+			require.NoError(t, os.RemoveAll(tempTestdataDir))
+		}()
+		t.Log("tempTestdataDir: ", tempTestdataDir)
+		tempXCResultPath := copyTestdataToDir(t, "./xcresults/xcresult3-flaky-with-rerun.xcresult", tempTestdataDir)
+
+		c := Converter{
+			xcresultPth: tempXCResultPath,
+		}
+		junitXML, err := c.XML()
+		require.NoError(t, err)
+		require.Equal(t, []junit.TestSuite{
+			{
+				Name: "BullsEyeTests", Tests: 5, Failures: 0, Skipped: 0, Errors: 0, Time: 0.9777920246124268,
+				TestCases: []junit.TestCase{
+					{
+						Name: "testStartNewRoundUsesRandomValueFromApiRequest()", ClassName: "BullsEyeFakeTests",
+						Time: 0.014459013938903809,
+					},
+					{
+						Name: "testGameStyleCanBeChanged()", ClassName: "BullsEyeMockTests",
+						Time: 0.00929105281829834,
+					},
+					{
+						Name: "testScoreIsComputedPerformance()", ClassName: "BullsEyeTests",
+						Time: 0.7373920679092407,
+					},
+					{
+						Name: "testScoreIsComputedWhenGuessIsHigherThanTarget()", ClassName: "BullsEyeTests",
+						Time: 0.004113912582397461,
+					},
+					{
+						Name: "testScoreIsComputedWhenGuessIsLowerThanTarget()", ClassName: "BullsEyeTests",
+						Time: 0.21253597736358643,
+					},
+				},
+			},
+			{
+				Name: "BullsEyeSlowTests", Tests: 2, Failures: 0, Skipped: 0, Errors: 0, Time: 0.5334550142288208,
+				TestCases: []junit.TestCase{
+					{
+						Name: "testApiCallCompletes()", ClassName: "BullsEyeSlowTests",
+						Time: 0.2844870090484619,
+					},
+					{
+						Name: "testValidApiCallGetsHTTPStatusCode200()", ClassName: "BullsEyeSlowTests",
+						Time: 0.2489680051803589,
+					},
+				},
+			},
+			{
+				Name: "BullsEyeUITests", Tests: 1, Failures: 0, Skipped: 0, Errors: 0, Time: 9.606701016426086,
+				TestCases: []junit.TestCase{
+					{
+						Name: "testGameStyleSwitch()", ClassName: "BullsEyeUITests",
+						Time: 9.606701016426086,
+					},
+				},
+			},
+			{ // testFlakyFeature() was flaky: failed once, and then passed the second run
+				Name: "BullsEyeFlakyTests", Tests: 3, Failures: 1, Skipped: 1, Errors: 0, Time: 0.22202682495117188,
+				TestCases: []junit.TestCase{
+					{
+						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.1958599090576172,
+						Failure: &junit.Failure{
+							Value: "/Users/vagrant/git/BullsEyeFlakyTests/BullsEyeFlakyTests.swift:43 - XCTAssertEqual failed: (\"1\") is not equal to (\"0\") - Number is not even\n",
+						},
+					},
+					{
+						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.00603795051574707,
+					},
+					{
+						Name: "testFlakySkip()", ClassName: "BullsEyeSkippedTests", Time: 0.020128965377807617,
+						Skipped: &junit.Skipped{},
+					},
+				},
+			},
+		}, junitXML.TestSuites)
+	})
+
 	t.Run("xcresults3 success-failed-skipped-tests.xcresult", func(t *testing.T) {
 		// copy test data to tmp dir
 		tempTestdataDir, err := pathutil.NormalizedOSTempDirPath("test")
@@ -45,7 +131,7 @@ func TestConverter_XML(t *testing.T) {
 		junitXML, err := c.XML()
 		require.NoError(t, err)
 		require.Equal(t, []junit.TestSuite{
-			junit.TestSuite{
+			{
 				Name:     "testProjectUITests",
 				Tests:    3,
 				Failures: 1,
@@ -53,21 +139,21 @@ func TestConverter_XML(t *testing.T) {
 				Errors:   0,
 				Time:     0.43262600898742676,
 				TestCases: []junit.TestCase{
-					junit.TestCase{
+					{
 						Name:      "testFailure()",
 						ClassName: "testProjectUITests",
 						Time:      0.2580660581588745,
 						Failure: &junit.Failure{
-							Value: "file:///Users/alexeysomov/Library/Autosave%20Information/testProject/testProjectUITests/testProjectUITests.swift:CharacterRangeLen=0&EndingLineNumber=29&StartingLineNumber=29 - XCTAssertTrue failed",
+							Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed\n",
 						},
 					},
-					junit.TestCase{
+					{
 						Name:      "testSkip()",
 						ClassName: "testProjectUITests",
 						Time:      0.08595001697540283,
 						Skipped:   &junit.Skipped{},
 					},
-					junit.TestCase{
+					{
 						Name:      "testSuccess()",
 						ClassName: "testProjectUITests",
 						Time:      0.08860993385314941,


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

I'd suggest a *MINOR* [version update](https://semver.org/).

There should be no breaking changes, but the logic of how we decide for xcresult3 report if a given test is failed changed.
Previously it was based on whether the code could find a failure for it in the failure summaries, while the new code now depends on the test's `TestStatus.Value == "Failure"`.

That said, there's one semi-breaking-change: the Failure Message in the xcresult3->junit generated report changed. Previously it included a url encoded reference (which is what the "issues" summary has as an error message), while the new solution now constructs the error message itself with the format: `file-path:line-number - error message`. You can see an example of this change here: https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io/pull/152/files#diff-8f7805bc321215ea75557289f345cd1e7f9d2a325d04030fe5ed93bb93dde224L61

**As far as we know this isn't a breaking change, but might worth a chat.**

### Context

Fixing the issue when the xcresult3 report includes a flaky test,
performed in "retry on failure" mode,
where the exact same test case first fails,
and then succeeds on the retry/rerun.

The previous implementation generated a junit report
which included both runs of the test case,
but both were marked as failed,
while the expected output would be a junit
report with a failed and then a successful run for the same (flaky) test case.

### Changes

The primary change is that xcresult3 `XML()` no longer determines whether the test failed or not by checking the `test-suite-name` + `test-case-name` in the "issues" summary list, because if you have "retry on failure" enabled then the report can include the same test case (where `test-suite-name` + `test-case-name` is the same) multiple times.

The previous logic simply picked the first match, so when the report included the same test case once as failed and once as successful (success on retry) the previous logic falsly listed the test case as failed 2 times. The new code will now list it as 1 failed 1 success in the generated junit report.

### Investigation details

x

### Decisions

x