### PR TITLE
[BINS-515] xcresult to junit conversion optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# TODO
+
+- Add timestamps to detection, conversion, upload - so we can tell from the logs where the time is spent the most
+
 # Bitrise Deploy Step
 
 Generic Bitrise deployer Step.
@@ -18,7 +22,9 @@ Step by step:
 3. `cd` into the directory of the step (the one which was just `git clone`d)
 5. Create a `.bitrise.secrets.yml` file in the same directory of `bitrise.yml` - the `.bitrise.secrets.yml` is a git ignored file, you can store your secrets in
 6. Check the `bitrise.yml` file for any secret you should set in `.bitrise.secrets.yml`
-  * Best practice is to mark these options with something like `# define these in your .bitrise.secrets.yml`, in the `app:envs` section.
+
+- Best practice is to mark these options with something like `# define these in your .bitrise.secrets.yml`, in the `app:envs` section.
+
 7. Once you have all the required secret parameters in your `.bitrise.secrets.yml` you can just run this step with the [bitrise CLI](https://github.com/bitrise-io/bitrise): `bitrise run test`
 
 An example `.bitrise.secrets.yml` file:
@@ -39,7 +45,7 @@ envs:
 6. Provide test values for the inputs in the `bitrise.yml`
 7. Run your step with `bitrise run test` - if it works, you're ready
 
-__For Step development guidelines & best practices__ check this documentation: [https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md).
+**For Step development guidelines & best practices** check this documentation: [https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md).
 
 **NOTE**
 
@@ -67,13 +73,14 @@ in the [bitrise CLI repository](https://github.com/bitrise-io/bitrise/blob/maste
 4. To use/test the step just follow the **How to use this Step** section
 5. Do the changes you want to do
 6. Run/test the step before sending your contribution
-  * You can also test the step in your `bitrise` project, either on your Mac or on [bitrise.io](https://www.bitrise.io)
-  * You just have to replace the step ID in your project's `bitrise.yml` with either a relative path, or with a git URL format
-  * (relative) path format: instead of `- original-step-id:` use `- path::./relative/path/of/script/on/your/Mac:`
-  * direct git URL format: instead of `- original-step-id:` use `- git::https://github.com/user/step.git@branch:`
-  * You can find more example of alternative step referencing at: https://github.com/bitrise-io/bitrise/blob/master/_examples/tutorials/steps-and-workflows/bitrise.yml
-7. Once you're done, commit your changes & create a Pull Request
 
+- You can also test the step in your `bitrise` project, either on your Mac or on [bitrise.io](https://www.bitrise.io)
+- You just have to replace the step ID in your project's `bitrise.yml` with either a relative path, or with a git URL format
+- (relative) path format: instead of `- original-step-id:` use `- path::./relative/path/of/script/on/your/Mac:`
+- direct git URL format: instead of `- original-step-id:` use `- git::https://github.com/user/step.git@branch:`
+- You can find more example of alternative step referencing at: <https://github.com/bitrise-io/bitrise/blob/master/_examples/tutorials/steps-and-workflows/bitrise.yml>
+
+7. Once you're done, commit your changes & create a Pull Request
 
 ## Share your own Step
 
@@ -92,5 +99,5 @@ That's all ;)
 
 ## Trigger a new release
 
-- __merge every code changes__ to the `master` branch
-- __push the new version tag__ to the `master` branch
+- **merge every code changes** to the `master` branch
+- **push the new version tag** to the `master` branch

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -152,7 +152,7 @@ func genTestSuite(name string,
 	testSuite.TestCases = make([]junit.TestCase, len(tests))
 	log.Printf("--> len(tests): %v", len(tests))
 
-	maxParallel := runtime.NumCPU() * 10
+	maxParallel := runtime.NumCPU() * 2
 	log.Printf("maxParallel: %v", maxParallel)
 	testIdx := 0
 	for testIdx < len(tests) {

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -3,8 +3,11 @@ package xcresult3
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
@@ -94,73 +97,141 @@ func (c *Converter) XML() (junit.XML, error) {
 	}
 
 	var xmlData junit.XML
-	for _, summary := range summaries {
+	{
+		testSuiteCount := testSuiteCountInSummaries(summaries)
+		xmlData.TestSuites = make([]junit.TestSuite, testSuiteCount)
+	}
+	summariesCount := len(summaries)
+	log.Printf("Summaries Count: %d", summariesCount)
+	for summaryIdx, summary := range summaries {
 		testSuiteOrder, testsByName := summary.tests()
 
-		for _, name := range testSuiteOrder {
+		for testSuiteIdx, name := range testSuiteOrder {
 			tests := testsByName[name]
 
-			testSuit := junit.TestSuite{
-				Name:     name,
-				Tests:    len(tests),
-				Failures: summary.failuresCount(name),
-				Skipped:  summary.skippedCount(name),
-				Time:     summary.totalTime(name),
+			testSuite, err := genTestSuite(name, summary, tests, testResultDir, c.xcresultPth)
+			if err != nil {
+				return junit.XML{}, err
 			}
 
-			for _, test := range tests {
-				var duartion float64
-				if test.Duration.Value != "" {
-					duartion, err = strconv.ParseFloat(test.Duration.Value, 64)
-					if err != nil {
-						return junit.XML{}, err
-					}
-				}
-
-				var failure *junit.Failure
-				var skipped *junit.Skipped
-				switch test.TestStatus.Value {
-				case "Failure":
-					testSummary, err := test.loadActionTestSummary(c.xcresultPth)
-					if err != nil {
-						return junit.XML{}, err
-					}
-
-					failureMessage := ""
-					for _, aTestFailureSummary := range testSummary.FailureSummaries.Values {
-						file := aTestFailureSummary.FileName.Value
-						line := aTestFailureSummary.LineNumber.Value
-						message := aTestFailureSummary.Message.Value
-
-						if len(failureMessage) > 0 {
-							failureMessage += "\n"
-						}
-						failureMessage += fmt.Sprintf("%s:%s - %s", file, line, message)
-					}
-
-					failure = &junit.Failure{
-						Value: failureMessage,
-					}
-				case "Skipped":
-					skipped = &junit.Skipped{}
-				}
-
-				testSuit.TestCases = append(testSuit.TestCases, junit.TestCase{
-					Name:      test.Name.Value,
-					ClassName: strings.Split(test.Identifier.Value, "/")[0],
-					Failure:   failure,
-					Skipped:   skipped,
-					Time:      duartion,
-				})
-
-				if err := test.exportScreenshots(c.xcresultPth, testResultDir); err != nil {
-					return junit.XML{}, err
-				}
-			}
-
-			xmlData.TestSuites = append(xmlData.TestSuites, testSuit)
+			xmlData.TestSuites[summaryIdx*summariesCount+testSuiteIdx] = testSuite
 		}
 	}
 
 	return xmlData, nil
+}
+
+func testSuiteCountInSummaries(summaries []ActionTestPlanRunSummaries) int {
+	testSuiteCount := 0
+	for _, summary := range summaries {
+		testSuiteOrder, _ := summary.tests()
+		testSuiteCount += len(testSuiteOrder)
+	}
+	return testSuiteCount
+}
+
+func genTestSuite(name string,
+	summary ActionTestPlanRunSummaries,
+	tests []ActionTestSummaryGroup,
+	testResultDir string,
+	xcresultPath string,
+) (junit.TestSuite, error) {
+	t1 := time.Now()
+	log.Printf("=> Generating test suite [%s] - started ...", name)
+	testSuite := junit.TestSuite{
+		Name:     name,
+		Tests:    len(tests),
+		Failures: summary.failuresCount(name),
+		Skipped:  summary.skippedCount(name),
+		Time:     summary.totalTime(name),
+	}
+
+	var genTestSuiteErr error
+	var wg sync.WaitGroup
+	var mtx sync.RWMutex
+	testSuite.TestCases = make([]junit.TestCase, len(tests))
+	log.Printf("--> len(tests): %v", len(tests))
+
+	maxParallel := runtime.NumCPU() * 10
+	log.Printf("maxParallel: %v", maxParallel)
+	testIdx := 0
+	for testIdx < len(tests) {
+		for i := 0; i < maxParallel && testIdx < len(tests); i++ {
+			test := tests[testIdx]
+			wg.Add(1)
+
+			go func(test ActionTestSummaryGroup, testIdx int) {
+				defer wg.Done()
+
+				testCase, err := genTestCase(test, xcresultPath, testResultDir)
+				if err != nil {
+					mtx.Lock()
+					genTestSuiteErr = err
+					mtx.Unlock()
+				}
+
+				testSuite.TestCases[testIdx] = testCase
+			}(test, testIdx)
+
+			testIdx += 1
+		}
+
+		wg.Wait()
+	}
+
+	t2 := time.Now()
+	log.Printf("-> Generating test suite [%s] - DONE %v", name, t2.Sub(t1))
+
+	return testSuite, genTestSuiteErr
+}
+
+func genTestCase(test ActionTestSummaryGroup, xcresultPath, testResultDir string) (junit.TestCase, error) {
+	var duartion float64
+	if test.Duration.Value != "" {
+		var err error
+		duartion, err = strconv.ParseFloat(test.Duration.Value, 64)
+		if err != nil {
+			return junit.TestCase{}, err
+		}
+	}
+
+	var failure *junit.Failure
+	var skipped *junit.Skipped
+	switch test.TestStatus.Value {
+	case "Failure":
+		testSummary, err := test.loadActionTestSummary(xcresultPath)
+		if err != nil {
+			return junit.TestCase{}, err
+		}
+
+		failureMessage := ""
+		for _, aTestFailureSummary := range testSummary.FailureSummaries.Values {
+			file := aTestFailureSummary.FileName.Value
+			line := aTestFailureSummary.LineNumber.Value
+			message := aTestFailureSummary.Message.Value
+
+			if len(failureMessage) > 0 {
+				failureMessage += "\n"
+			}
+			failureMessage += fmt.Sprintf("%s:%s - %s", file, line, message)
+		}
+
+		failure = &junit.Failure{
+			Value: failureMessage,
+		}
+	case "Skipped":
+		skipped = &junit.Skipped{}
+	}
+
+	if err := test.exportScreenshots(xcresultPath, testResultDir); err != nil {
+		return junit.TestCase{}, err
+	}
+
+	return junit.TestCase{
+		Name:      test.Name.Value,
+		ClassName: strings.Split(test.Identifier.Value, "/")[0],
+		Failure:   failure,
+		Skipped:   skipped,
+		Time:      duartion,
+	}, nil
 }

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -163,3 +163,55 @@ func TestConverter_XML(t *testing.T) {
 		}, junitXML.TestSuites)
 	})
 }
+
+func TestConverter_XML_Large_Tests_xcresult(t *testing.T) {
+	t.Run("Large-Tests.xcresult", func(t *testing.T) {
+		// copy test data to tmp dir
+		tempTestdataDir, err := pathutil.NormalizedOSTempDirPath("test")
+		if err != nil {
+			t.Fatal("failed to create temp dir, error:", err)
+		}
+		defer func() {
+			require.NoError(t, os.RemoveAll(tempTestdataDir))
+		}()
+		t.Log("tempTestdataDir: ", tempTestdataDir)
+		tempXCResultPath := copyTestdataToDir(t, "./xcresults/Large-Tests.xcresult", tempTestdataDir)
+
+		c := Converter{
+			xcresultPth: tempXCResultPath,
+		}
+		junitXML, err := c.XML()
+		require.NoError(t, err)
+		require.Equal(t, []junit.TestSuite{
+			{
+				Name:     "testProjectUITests",
+				Tests:    3,
+				Failures: 1,
+				Skipped:  1,
+				Errors:   0,
+				Time:     0.43262600898742676,
+				TestCases: []junit.TestCase{
+					{
+						Name:      "testFailure()",
+						ClassName: "testProjectUITests",
+						Time:      0.2580660581588745,
+						Failure: &junit.Failure{
+							Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed",
+						},
+					},
+					{
+						Name:      "testSkip()",
+						ClassName: "testProjectUITests",
+						Time:      0.08595001697540283,
+						Skipped:   &junit.Skipped{},
+					},
+					{
+						Name:      "testSuccess()",
+						ClassName: "testProjectUITests",
+						Time:      0.08860993385314941,
+					},
+				},
+			},
+		}, junitXML.TestSuites)
+	})
+}

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -16,7 +16,7 @@ import (
 // run `bitrise run download_sample_artifacts` before running tests here,
 // which will download https://github.com/bitrise-io/sample-artifacts
 // into the _tmp dir.
-func copyTestdataToDir(t *testing.T, pathInTestdataDir, dirPathToCopyInto string) string {
+func copyTestdataToDir(t require.TestingT, pathInTestdataDir, dirPathToCopyInto string) string {
 	err := command.CopyDir(
 		filepath.Join("../../../_tmp/", pathInTestdataDir),
 		dirPathToCopyInto,
@@ -164,54 +164,52 @@ func TestConverter_XML(t *testing.T) {
 	})
 }
 
-func TestConverter_XML_Large_Tests_xcresult(t *testing.T) {
-	t.Run("Large-Tests.xcresult", func(t *testing.T) {
-		// copy test data to tmp dir
-		tempTestdataDir, err := pathutil.NormalizedOSTempDirPath("test")
-		if err != nil {
-			t.Fatal("failed to create temp dir, error:", err)
-		}
-		defer func() {
-			require.NoError(t, os.RemoveAll(tempTestdataDir))
-		}()
-		t.Log("tempTestdataDir: ", tempTestdataDir)
-		tempXCResultPath := copyTestdataToDir(t, "./xcresults/Large-Tests.xcresult", tempTestdataDir)
+func BenchmarkConverter_XML_Large_Tests_xcresult(b *testing.B) {
+	// copy test data to tmp dir
+	tempTestdataDir, err := pathutil.NormalizedOSTempDirPath("test")
+	if err != nil {
+		b.Fatal("failed to create temp dir, error:", err)
+	}
+	defer func() {
+		require.NoError(b, os.RemoveAll(tempTestdataDir))
+	}()
+	b.Log("tempTestdataDir: ", tempTestdataDir)
+	tempXCResultPath := copyTestdataToDir(b, "./xcresults/Large-Tests.xcresult", tempTestdataDir)
 
-		c := Converter{
-			xcresultPth: tempXCResultPath,
-		}
-		junitXML, err := c.XML()
-		require.NoError(t, err)
-		require.Equal(t, []junit.TestSuite{
-			{
-				Name:     "testProjectUITests",
-				Tests:    3,
-				Failures: 1,
-				Skipped:  1,
-				Errors:   0,
-				Time:     0.43262600898742676,
-				TestCases: []junit.TestCase{
-					{
-						Name:      "testFailure()",
-						ClassName: "testProjectUITests",
-						Time:      0.2580660581588745,
-						Failure: &junit.Failure{
-							Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed",
-						},
-					},
-					{
-						Name:      "testSkip()",
-						ClassName: "testProjectUITests",
-						Time:      0.08595001697540283,
-						Skipped:   &junit.Skipped{},
-					},
-					{
-						Name:      "testSuccess()",
-						ClassName: "testProjectUITests",
-						Time:      0.08860993385314941,
-					},
-				},
-			},
-		}, junitXML.TestSuites)
-	})
+	c := Converter{
+		xcresultPth: tempXCResultPath,
+	}
+	_, err = c.XML()
+	require.NoError(b, err)
+	// require.Equal(b, []junit.TestSuite{
+	// 	{
+	// 		Name:     "testProjectUITests",
+	// 		Tests:    3,
+	// 		Failures: 1,
+	// 		Skipped:  1,
+	// 		Errors:   0,
+	// 		Time:     0.43262600898742676,
+	// 		TestCases: []junit.TestCase{
+	// 			{
+	// 				Name:      "testFailure()",
+	// 				ClassName: "testProjectUITests",
+	// 				Time:      0.2580660581588745,
+	// 				Failure: &junit.Failure{
+	// 					Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed",
+	// 				},
+	// 			},
+	// 			{
+	// 				Name:      "testSkip()",
+	// 				ClassName: "testProjectUITests",
+	// 				Time:      0.08595001697540283,
+	// 				Skipped:   &junit.Skipped{},
+	// 			},
+	// 			{
+	// 				Name:      "testSuccess()",
+	// 				ClassName: "testProjectUITests",
+	// 				Time:      0.08860993385314941,
+	// 			},
+	// 		},
+	// 	},
+	// }, junitXML.TestSuites)
 }

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -181,35 +181,4 @@ func BenchmarkConverter_XML_Large_Tests_xcresult(b *testing.B) {
 	}
 	_, err = c.XML()
 	require.NoError(b, err)
-	// require.Equal(b, []junit.TestSuite{
-	// 	{
-	// 		Name:     "testProjectUITests",
-	// 		Tests:    3,
-	// 		Failures: 1,
-	// 		Skipped:  1,
-	// 		Errors:   0,
-	// 		Time:     0.43262600898742676,
-	// 		TestCases: []junit.TestCase{
-	// 			{
-	// 				Name:      "testFailure()",
-	// 				ClassName: "testProjectUITests",
-	// 				Time:      0.2580660581588745,
-	// 				Failure: &junit.Failure{
-	// 					Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed",
-	// 				},
-	// 			},
-	// 			{
-	// 				Name:      "testSkip()",
-	// 				ClassName: "testProjectUITests",
-	// 				Time:      0.08595001697540283,
-	// 				Skipped:   &junit.Skipped{},
-	// 			},
-	// 			{
-	// 				Name:      "testSuccess()",
-	// 				ClassName: "testProjectUITests",
-	// 				Time:      0.08860993385314941,
-	// 			},
-	// 		},
-	// 	},
-	// }, junitXML.TestSuites)
 }


### PR DESCRIPTION
This PR affects only the xcresult3 to junit conversion.

In that case it'll run all the test case conversions in parallel.

## Why?

The `xcresulttoolGet` call, which we run for every test case to determine if it has an attached screenshot, takes about 20ms. Ref: https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io/blob/fd92ed83c3928d8b93d39dcad00633f2df0b1bfb/test/converters/xcresult3/action_test_summary_group.go#L97

This means that for a test report which has 4000 test cases these xcresulttool calls will take about 80 seconds on an M1 Mac machine.

This PR improves this a bit by doing these calls in parallel.

## Data

On my personal M1 Mac with 10 cores this change improved the conversion time from 80 seconds to ~20 seconds.

On a Standard Bitrise macOS VM it improved from ~250 seconds to ~150 seconds.

## Further improvements

If we could get rid of that `xcresulttoolGet` call at https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io/blob/fd92ed83c3928d8b93d39dcad00633f2df0b1bfb/test/converters/xcresult3/action_test_summary_group.go#L97
we could get the conversion time down from ~250 seconds to ~12 seconds (!!) on a Standard Bitrise VM (tested, with a 4000 test case report which had no screenshots, so I just removed the `exportScreenshots` call).

Unfortunately I couldn't find a way yet to determine whether a test case has a related screenshots without that call, that needs further investigation.
