### PR TITLE
[SWAT-89] Add support for junit file extension

### DIFF
--- a/test/converters/junitxml/junitxml.go
+++ b/test/converters/junitxml/junitxml.go
@@ -38,7 +38,7 @@ type Converter struct {
 func (h *Converter) Detect(files []string) bool {
 	h.results = nil
 	for _, file := range files {
-		if strings.HasSuffix(file, ".xml") {
+		if strings.HasSuffix(file, ".xml") || strings.HasSuffix(file, ".junit") {
 			h.results = append(h.results, &fileReader{Filename: file})
 		}
 	}

--- a/test/converters/junitxml/junitxml_test.go
+++ b/test/converters/junitxml/junitxml_test.go
@@ -16,6 +16,7 @@ func Test_parseTestSuites(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "root element is testsuites", path: "./testdata/testsuites.xml", wantErr: false},
+		{name: "root element is another testsuites", path: "./testdata/testsuites.junit", wantErr: false},
 		{name: "root element is testsuite", path: "./testdata/testsuite.xml", wantErr: false},
 	}
 	for _, tt := range tests {

--- a/test/converters/junitxml/testdata/testsuites.junit
+++ b/test/converters/junitxml/testdata/testsuites.junit
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="0">
+    <testsuite name="TestApp" tests="2" failures="0" skipped="0" time="0.3645280599594116">
+        <properties>
+          <property name="Configuration" value="Test Scheme Action"/>
+        </properties>
+        <testcase classname="TestAppTests" name="testExample()" time="0.0009930133819580078">
+        </testcase>
+        <testcase classname="TestAppTests" name="testPerformanceExample()" time="0.3635350465774536">
+        </testcase>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Fastlane saves the junit reports with a `.junit` file extension instead of an `.xml`. The content follows the same format, just the file extension has changed.

### Changes

- The junit converter now can parse the files with `junit` extension.
