### PR TITLE
Avoid using absolute path with tar command when archiving

### DIFF
--- a/main.go
+++ b/main.go
@@ -301,20 +301,13 @@ func archiveAsTar(sourceDirPath, destinationTarPath string, isContentOnly bool) 
 	fmt.Println()
 	log.Infof("Archiving directory...")
 
-	// Note: The tar command can't change the pathname of the files
-	// when unarchiving so we need to avoid using the absolute path
-	// of the directory. Hence we set the working directory as the
-	// parent directory of the directory we're archiving.
-	// https://docstore.mik.ua/orelly/unix/upt/ch20_10.htm
-	workDir := strings.TrimRight(sourceDirPath, "/")
-	workDir = filepath.Dir(workDir)           //get the parent
-	sourceDir := filepath.Base(sourceDirPath) //the directory we're going to archive
-
-	// -c - create a new archive
-	// -f - the next argument is the name of the output archive
+	// -c - Create a new archive
+	// -f - The next argument is the name of the output archive
+	// -C - The `-C sourceDir` tells tar to change the current directory to sourceDir,
+	// and then . means "add the entire current directory". This allows us to avoid
+	// adding the directory itself to the archive and only include its contents.
 	// Note: Recursive behavior is default in tar.
-	cmd := command.New("tar", "cf", destinationTarPath, sourceDir)
-	cmd = cmd.SetDir(workDir)
+	cmd := command.New("tar", "cf", destinationTarPath, "-C", sourceDirPath, ".")
 
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
 		err = fmt.Errorf("command: (%s) failed, output: %s, error: %s", cmd.PrintableCommandArgs(), out, err)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

Fixes #162 (SWAT-816)

The `tar` command can't change the pathname of the files when unarchiving so we need to avoid using the absolute path of the directory. Hence we set the working directory as the parent directory of the directory we're archiving via the `-C` argument when invoking `tar`.

https://docstore.mik.ua/orelly/unix/upt/ch20_10.htm

https://stackoverflow.com/a/3035446

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

We now execute `tar cf /path/of/output.tar -C /path/of/directory_to_archive/ .`

The `-C` argument makes `tar` switch to the given directory before archiving and we pass `.` in order to denote that all files in that directory should be archived.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

Originally tried to just set the working directory of the command, but that led to an extra parent directory when unarchiving.

Example:

```
tar cf my_directory.tar my_directory
tar xf my_directory.tar

output:
my_directory
   --- my_file
   --- my_file
   --- my_file
```

After extracting we have the files we want contained in `my_directory` which is not what the subsequent pull pipeline intermediates step was expecting.

### Decisions

<!-- Please list decisions that were made for this change. -->
