### PR TITLE
Revert to zipping pipeline intermediates

### DIFF
--- a/deployment/collector.go
+++ b/deployment/collector.go
@@ -40,8 +40,8 @@ func ConvertPaths(paths []string) []DeployableItem {
 	return items
 }
 
-// ArchiveDirFunction ...
-type ArchiveDirFunction func(sourceDirPath, outputPath string, isContentOnly bool) error
+// ZipDirFunction ...
+type ZipDirFunction func(sourceDirPth, destinationZipPth string, isContentOnly bool) error
 
 // IsDirFunction ...
 type IsDirFunction func(path string) (bool, error)
@@ -58,21 +58,21 @@ func DefaultIsDirFunction(path string) (bool, error) {
 
 // Collector ...
 type Collector struct {
-	isDirFunction      IsDirFunction
-	archiveDirFunction ArchiveDirFunction
-	temporaryFolder    string
+	isDirFunction   IsDirFunction
+	zipDirFunction  ZipDirFunction
+	temporaryFolder string
 }
 
 // NewCollector ...
 func NewCollector(
 	isDirFunction IsDirFunction,
-	archiveDirFunction ArchiveDirFunction,
+	zipDirFunction ZipDirFunction,
 	temporaryFolder string,
 ) Collector {
 	return Collector{
-		isDirFunction:      isDirFunction,
-		archiveDirFunction: archiveDirFunction,
-		temporaryFolder:    temporaryFolder,
+		isDirFunction:   isDirFunction,
+		zipDirFunction:  zipDirFunction,
+		temporaryFolder: temporaryFolder,
 	}
 }
 
@@ -88,7 +88,7 @@ func (c Collector) AddIntermediateFiles(deployableItems []DeployableItem, interm
 		return []DeployableItem{}, err
 	}
 
-	deployableItems, err = c.archiveDirectories(deployableItems)
+	deployableItems, err = c.zipDirectories(deployableItems)
 	if err != nil {
 		return []DeployableItem{}, err
 	}
@@ -180,10 +180,10 @@ func (c Collector) indexOfItemWithPath(items []DeployableItem, path string) int 
 	return -1
 }
 
-func (c Collector) archiveDirectories(items []DeployableItem) ([]DeployableItem, error) {
+func (c Collector) zipDirectories(items []DeployableItem) ([]DeployableItem, error) {
 	for i, item := range items {
 		if item.IntermediateFileMeta != nil && item.IntermediateFileMeta.IsDir {
-			path, err := c.archiveDir(item.Path)
+			path, err := c.zipDir(item.Path)
 			if err != nil {
 				return nil, err
 			}
@@ -195,13 +195,13 @@ func (c Collector) archiveDirectories(items []DeployableItem) ([]DeployableItem,
 	return items, nil
 }
 
-func (c Collector) archiveDir(path string) (string, error) {
+func (c Collector) zipDir(path string) (string, error) {
 	name := filepath.Base(path)
-	targetPath := filepath.Join(c.temporaryFolder, name+".tar")
+	targetPth := filepath.Join(c.temporaryFolder, name+".zip")
 
-	if err := c.archiveDirFunction(path, targetPath, true); err != nil {
-		return "", fmt.Errorf("failed to archive output dir, error: %s", err)
+	if err := c.zipDirFunction(path, targetPth, true); err != nil {
+		return "", fmt.Errorf("failed to zip output dir, error: %s", err)
 	}
 
-	return targetPath, nil
+	return targetPth, nil
 }

--- a/deployment/collector_test.go
+++ b/deployment/collector_test.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,21 +80,21 @@ func Test_GivenIntermediateFiles_WhenProcessing_ThenConvertsCorrectly(t *testing
 			list: "/output_folder:OUTPUT_FOLDER" + "\n" + "./local/build:BUILD_DIRECTORY" + "\n" + "folder:JUST_A_FOLDER",
 			want: []DeployableItem{
 				{
-					Path: filepath.Join(tempDir, "output_folder.tar"),
+					Path: filepath.Join(tempDir, "output_folder.zip"),
 					IntermediateFileMeta: &IntermediateFileMetaData{
 						EnvKey: "OUTPUT_FOLDER",
 						IsDir:  true,
 					},
 				},
 				{
-					Path: filepath.Join(tempDir, "build.tar"),
+					Path: filepath.Join(tempDir, "build.zip"),
 					IntermediateFileMeta: &IntermediateFileMetaData{
 						EnvKey: "BUILD_DIRECTORY",
 						IsDir:  true,
 					},
 				},
 				{
-					Path: filepath.Join(tempDir, "folder.tar"),
+					Path: filepath.Join(tempDir, "folder.zip"),
 					IntermediateFileMeta: &IntermediateFileMetaData{
 						EnvKey: "JUST_A_FOLDER",
 						IsDir:  true,
@@ -141,7 +142,7 @@ func Test_GivenIntermediateFiles_WhenProcessing_ThenConvertsCorrectly(t *testing
 
 			assert.NoError(t, err)
 
-			if !assert.ElementsMatch(t, deployableItems, tt.want) {
+			if !reflect.DeepEqual(deployableItems, tt.want) {
 				t.Errorf("%s got = %v, want %v", t.Name(), deployableItems, tt.want)
 			}
 		})
@@ -264,7 +265,7 @@ func Test_GivenDeployFiles_WhenIntermediateFilesSpecified_ThenMergesThem(t *test
 
 			assert.NoError(t, err)
 
-			if !assert.ElementsMatch(t, deployableItems, tt.want) {
+			if !reflect.DeepEqual(deployableItems, tt.want) {
 				t.Errorf("%s got = %v, want %v", t.Name(), deployableItems, tt.want)
 			}
 		})
@@ -285,7 +286,7 @@ func isDirFunction(directoryEntries []string) IsDirFunction {
 	}
 }
 
-func emptyZipFunction() ArchiveDirFunction {
+func emptyZipFunction() ZipDirFunction {
 	return func(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bitrise-io/envman/envman"
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"
-	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/ziputil"
@@ -98,7 +97,7 @@ func main() {
 	}
 
 	if strings.TrimSpace(config.PipelineIntermediateFiles) != "" {
-		collector := deployment.NewCollector(deployment.DefaultIsDirFunction, archiveAsTar, tmpDir)
+		collector := deployment.NewCollector(deployment.DefaultIsDirFunction, ziputil.ZipDir, tmpDir)
 		deployableItems, err = collector.AddIntermediateFiles(deployableItems, config.PipelineIntermediateFiles)
 		if err != nil {
 			fail("%s", err)
@@ -295,23 +294,6 @@ func collectFilesToDeploy(absDeployPth string, config Config, tmpDir string) (fi
 	}
 
 	return filesToDeploy, nil
-}
-
-func archiveAsTar(sourceDirPath, destinationTarPath string, isContentOnly bool) error {
-	fmt.Println()
-	log.Infof("Compressing directory...")
-
-	// -c - create a new archive
-	// -f - the next argument is the name of the output archive
-	// Note: recursive behavior is default in tar
-	cmd := command.New("tar", "cf", destinationTarPath, sourceDirPath)
-
-	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
-		err = fmt.Errorf("command: (%s) failed, output: %s, error: %s", cmd.PrintableCommandArgs(), out, err)
-		return err
-	}
-
-	return nil
 }
 
 func deployTestResults(config Config) {

--- a/main.go
+++ b/main.go
@@ -299,15 +299,12 @@ func collectFilesToDeploy(absDeployPth string, config Config, tmpDir string) (fi
 
 func archiveAsTar(sourceDirPath, destinationTarPath string, isContentOnly bool) error {
 	fmt.Println()
-	log.Infof("Archiving directory...")
+	log.Infof("Compressing directory...")
 
-	// -c - Create a new archive
-	// -f - The next argument is the name of the output archive
-	// -C - The `-C sourceDir` tells tar to change the current directory to sourceDir,
-	// and then . means "add the entire current directory". This allows us to avoid
-	// adding the directory itself to the archive and only include its contents.
-	// Note: Recursive behavior is default in tar.
-	cmd := command.New("tar", "cf", destinationTarPath, "-C", sourceDirPath, ".")
+	// -c - create a new archive
+	// -f - the next argument is the name of the output archive
+	// Note: recursive behavior is default in tar
+	cmd := command.New("tar", "cf", destinationTarPath, sourceDirPath)
 
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
 		err = fmt.Errorf("command: (%s) failed, output: %s, error: %s", cmd.PrintableCommandArgs(), out, err)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

We discussed that using `zip` for build artifacts and `tar` for pipeline intermediates is not ideal moving forward due to having to maintain both tools across stacks.

Here's the accompanying `pull-pipeline-intermediates` PR: https://github.com/bitrise-steplib/bitrise-step-pull-intermediate-files/pull/3

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Reverting the changes from previous releases. Leaving vendored dependencies.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

Also considered just compressing pipeline intermediates with the existing changes to `tar`.

Note: `zip` throws an error when zipping empty directories.

Details are here under error code 12: https://linux.die.net/man/1/zip

To work around this for the e2e tests I added a file to the directory.

### Decisions

<!-- Please list decisions that were made for this change. -->

The plan moving forward is to consolidate and use `zip` across the board instead of making additional changes to accommodate `tar` in order to avoid having to maintain both tools across stacks. `zip` also gives the benefit of compressing the archive by default.
