### PR TITLE
Handle xcarchive parsing errors gracefully

### DIFF
--- a/uploaders/xcarchiveuploader.go
+++ b/uploaders/xcarchiveuploader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
 
+// DeployXcarchive ...
 func DeployXcarchive(item deployment.DeployableItem, buildURL, token string) (ArtifactURLs, error) {
 	uploadURL, artifactID, err := createArtifact(buildURL, token, item.Path, "ios-xcarchive", "")
 	if err != nil {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

We treat every parsing error as a fatal error that interrupts the upload and makes the entire step fails. This is a bit too drastic, we should at least upload the given file as a plain artifact (without parsed metadata) in this case, so the user can take a look at the problematic file.

### Changes

- Extract xcarchive parsing into a separate function
- Treat the parsing failure as a warning and log the details
- Since metadata is an optimal parameter of the uploading function, we just pass the nil pointer to it if there is no parsed metadata

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

Fixing all other parser types (APK, AAB, IPA, etc.) is out of scope for this PR. It's just a quick fix to make matters slightly better, but if we see other parsing failures popping up often, let's dedicate some time to fixing all of them.
