### PR TITLE
Use aab specific package name key

### DIFF
--- a/androidartifact/apk_info.go
+++ b/androidartifact/apk_info.go
@@ -65,8 +65,13 @@ func parsePackageField(aaptOut, key string) string {
 }
 
 // ParsePackageInfos parses package name, version code and name from `aapt dump badging` command output.
-func ParsePackageInfos(aaptOut string) (string, string, string) {
-	return parsePackageField(aaptOut, "name"),
+func ParsePackageInfos(aaptOut string, isAAB bool) (string, string, string) {
+	packageNameKey := "name"
+	if isAAB {
+		packageNameKey = "package"
+	}
+
+	return parsePackageField(aaptOut, packageNameKey),
 		parsePackageField(aaptOut, "versionCode"),
 		parsePackageField(aaptOut, "versionName")
 }
@@ -144,7 +149,7 @@ func getAPKInfoWithAapt(apkPth string) (ApkInfo, error) {
 	}
 
 	appName := parseAppName(aaptOut)
-	packageName, versionCode, versionName := ParsePackageInfos(aaptOut)
+	packageName, versionCode, versionName := ParsePackageInfos(aaptOut, false)
 	minSDKVersion := parseMinSDKVersion(aaptOut)
 
 	packageContent := ""

--- a/androidartifact/apk_info_test.go
+++ b/androidartifact/apk_info_test.go
@@ -14,73 +14,82 @@ import (
 func TestParsePackageInfos(t *testing.T) {
 
 	tests := []struct {
-		name    string
-		aaptOut string
-		want    string
-		want1   string
-		want2   string
+		name        string
+		aaptOut     string
+		isAAB       bool
+		packageName string
+		versionCode string
+		versionName string
 	}{
 		{
-			name:    "test_with_empty_platformBuildVersionName",
-			aaptOut: `package: name='com.example.birmachera.myapplication' versionCode='1' versionName='1.0' platformBuildVersionName=''`,
-			want:    "com.example.birmachera.myapplication",
-			want1:   "1",
-			want2:   "1.0",
+			name:        "test_with_empty_platformBuildVersionName",
+			aaptOut:     `package: name='com.example.birmachera.myapplication' versionCode='1' versionName='1.0' platformBuildVersionName=''`,
+			packageName: "com.example.birmachera.myapplication",
+			versionCode: "1",
+			versionName: "1.0",
 		},
 		{
-			name:    "test_without_platformBuildVersionName",
-			aaptOut: `package: name='com.example.birmachera.myapplication' versionCode='1' versionName='1.0'`,
-			want:    "com.example.birmachera.myapplication",
-			want1:   "1",
-			want2:   "1.0",
+			name:        "test_without_platformBuildVersionName",
+			aaptOut:     `package: name='com.example.birmachera.myapplication' versionCode='1' versionName='1.0'`,
+			packageName: "com.example.birmachera.myapplication",
+			versionCode: "1",
+			versionName: "1.0",
 		},
 		{
-			name:    "test_with_platformBuildVersionName",
-			aaptOut: `package: name='com.example.birmachera.myapplication' versionCode='1' versionName='1.0' platformBuildVersionName='3'`,
-			want:    "com.example.birmachera.myapplication",
-			want1:   "1",
-			want2:   "1.0",
+			name:        "test_with_platformBuildVersionName",
+			aaptOut:     `package: name='com.example.birmachera.myapplication' versionCode='1' versionName='1.0' platformBuildVersionName='3'`,
+			packageName: "com.example.birmachera.myapplication",
+			versionCode: "1",
+			versionName: "1.0",
 		},
 		{
-			name:    "test_without_name",
-			aaptOut: `package: name='' versionCode='1' versionName='1.0' platformBuildVersionName='3'`,
-			want:    "",
-			want1:   "1",
-			want2:   "1.0",
+			name:        "test_without_name",
+			aaptOut:     `package: name='' versionCode='1' versionName='1.0' platformBuildVersionName='3'`,
+			packageName: "",
+			versionCode: "1",
+			versionName: "1.0",
 		},
 		{
-			name:    "test_without_name_and_versionCode",
-			aaptOut: `package: name='' versionCode='' versionName='1.0' platformBuildVersionName='3'`,
-			want:    "",
-			want1:   "",
-			want2:   "1.0",
+			name:        "test_without_name_and_versionCode",
+			aaptOut:     `package: name='' versionCode='' versionName='1.0' platformBuildVersionName='3'`,
+			packageName: "",
+			versionCode: "",
+			versionName: "1.0",
 		},
 		{
-			name:    "test_without_name_and_versionCode_and_versionName",
-			aaptOut: `package: name='' versionCode='' versionName='' platformBuildVersionName='3'`,
-			want:    "",
-			want1:   "",
-			want2:   "",
+			name:        "test_without_name_and_versionCode_and_versionName",
+			aaptOut:     `package: name='' versionCode='' versionName='' platformBuildVersionName='3'`,
+			packageName: "",
+			versionCode: "",
+			versionName: "",
 		},
 		{
-			name:    "test_without_name_and_versionCode_and_versionName",
-			aaptOut: `package: name='' versionCode='2' versionName='' platformBuildVersionName='3'`,
-			want:    "",
-			want1:   "2",
-			want2:   "",
+			name:        "test_without_name_and_versionCode_and_versionName",
+			aaptOut:     `package: name='' versionCode='2' versionName='' platformBuildVersionName='3'`,
+			packageName: "",
+			versionCode: "2",
+			versionName: "",
+		},
+		{
+			name:        "test_aab_package_name_from_manifest",
+			aaptOut:     testArtifactAndroidManifest,
+			isAAB:       true,
+			packageName: "com.example.birmachera.myapplication",
+			versionCode: "1",
+			versionName: "1.0",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2 := ParsePackageInfos(tt.aaptOut)
-			if got != tt.want {
-				t.Errorf("ParsePackageInfos() got = %v, want %v", got, tt.want)
+			packageName, versionCode, versionName := ParsePackageInfos(tt.aaptOut, tt.isAAB)
+			if packageName != tt.packageName {
+				t.Errorf("packageName got = %v, want %v", packageName, tt.packageName)
 			}
-			if got1 != tt.want1 {
-				t.Errorf("ParsePackageInfos() got1 = %v, want %v", got1, tt.want1)
+			if versionCode != tt.versionCode {
+				t.Errorf("versionCode got = %v, want %v", versionCode, tt.versionCode)
 			}
-			if got2 != tt.want2 {
-				t.Errorf("ParsePackageInfos() got2 = %v, want %v", got2, tt.want2)
+			if versionName != tt.versionName {
+				t.Errorf("versionName got = %v, want %v", versionName, tt.versionName)
 			}
 		})
 	}

--- a/uploaders/aabuploader.go
+++ b/uploaders/aabuploader.go
@@ -29,7 +29,7 @@ func DeployAAB(item deployment.DeployableItem, artifacts []string, buildURL, tok
 		return ArtifactURLs{}, fmt.Errorf("executing command failed (%s): %w", cmd.PrintableCommandArgs(), err)
 	}
 
-	packageName, versionCode, versionName := androidartifact.ParsePackageInfos(out)
+	packageName, versionCode, versionName := androidartifact.ParsePackageInfos(out, true)
 
 	appInfo := map[string]interface{}{
 		"package_name": packageName,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The aab metadata retrieval does not work well with aab files. It tries to fetch the package name the same way as for apk files but the key is different for aabs. For apks the `name` and for aabs the `package` should be used. 

### Changes

- Added a way to differentiate between aok and aab files
- Added a test case to cover the aab path
