### PR TITLE
Update bundletool version

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -184,7 +184,7 @@ inputs:
       value_options:
       - "true"
       - "false"
-  - bundletool_version: "1.8.1"
+  - bundletool_version: "1.15.0"
     opts:
       category: Build Artifact Deployment
       title: "Bundletool version"


### PR DESCRIPTION

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The bundletool used is over 1.5 years old. Meanwhile many improvements have been applied to the tool to support latest android features and packaging.

### Changes

Updates the bundletool default version. Here a list of release notes: https://github.com/google/bundletool/releases

### Decisions

We have experienced issues while the step was downloading that version of bundletool, failing the build. One step before we downloaded bundletool (latest) and the download was successful. I am aware that bumping version doesnt fix download issues but this is how I realized we were downloading a 1.5yo version.
