### PR TITLE
Flaky test reports

### DIFF
--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -93,16 +93,10 @@ func TestConverter_XML(t *testing.T) {
 				},
 			},
 			{ // testFlakyFeature() was flaky: failed once, and then passed the second run
-				Name: "BullsEyeFlakyTests", Tests: 3, Failures: 1, Skipped: 1, Errors: 0, Time: 0.22202682495117188,
+				Name: "BullsEyeFlakyTests", Tests: 2, Failures: 0, Skipped: 1, Errors: 0, Time: 0.22202682495117188,
 				TestCases: []junit.TestCase{
 					{
-						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.1958599090576172,
-						Failure: &junit.Failure{
-							Value: "/Users/vagrant/git/BullsEyeFlakyTests/BullsEyeFlakyTests.swift:43 - XCTAssertEqual failed: (\"1\") is not equal to (\"0\") - Number is not even",
-						},
-					},
-					{
-						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.00603795051574707,
+						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.201898,
 					},
 					{
 						Name: "testFlakySkip()", ClassName: "BullsEyeSkippedTests", Time: 0.020128965377807617,

--- a/test/converters/xcresult3/decorated_test_summary_groups.go
+++ b/test/converters/xcresult3/decorated_test_summary_groups.go
@@ -1,0 +1,67 @@
+package xcresult3
+
+import (
+	"strconv"
+	"fmt"
+	"github.com/bitrise-io/go-utils/log"
+)
+
+type DecoratedTestSummaryGroups struct {
+	tests     []ActionTestSummaryGroup
+	failures  int
+	skipped   int
+	flaky     int
+	totalTime float64
+}
+
+func parseDuration(test ActionTestSummaryGroup) (float64) {
+	if test.Duration.Value != "" {
+		d, err := strconv.ParseFloat(test.Duration.Value, 64)
+		if err == nil {
+			return d
+		}
+	}
+	return 0.0
+}
+
+func decorateTests(summaryGroups []ActionTestSummaryGroup) (DecoratedTestSummaryGroups) {
+
+    var failure int = 0
+    var skipped int = 0
+    var flaky   int = 0
+    var time float64 = 0.0
+
+	for testIndex, test := range summaryGroups {
+		if test.TestStatus.Value == "Failure" {
+			failure++
+		} else if test.TestStatus.Value == "Skipped" {
+			skipped++
+		}
+
+		if test.Duration.Value != "" {
+			d, err := strconv.ParseFloat(test.Duration.Value, 64)
+			if err == nil {
+				time += d
+			}
+		}
+
+        // Flaky correction
+		if testIndex > 0 && test.Identifier.Value == summaryGroups[testIndex-1].Identifier.Value {
+			summaryGroups[testIndex-1].TestStatus.Value = "Flaky"
+			flaky++
+			failure--
+			summaryGroups[testIndex].Duration.Value = fmt.Sprintf("%f", parseDuration(test) + parseDuration(summaryGroups[testIndex-1]))
+		}
+	}
+
+
+	decoratedTestSummaryGroups := DecoratedTestSummaryGroups {
+		tests: summaryGroups,
+		failures: failure,
+		skipped: skipped,
+		flaky: flaky,
+		totalTime: time,
+	}
+
+	return decoratedTestSummaryGroups
+}

--- a/test/converters/xcresult3/decorated_test_summary_groups.go
+++ b/test/converters/xcresult3/decorated_test_summary_groups.go
@@ -3,7 +3,6 @@ package xcresult3
 import (
 	"strconv"
 	"fmt"
-	"github.com/bitrise-io/go-utils/log"
 )
 
 type DecoratedTestSummaryGroups struct {


### PR DESCRIPTION
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a MINOR [version update](https://semver.org/)

### Context

It is fixing an issue where flaky tests weren't reported properly in the Test Reports Add On or in Bitrise Checks. Reporting flaky tests as failures on Bitrise Checks would block merging.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

This change is mapping each group of flaky tests into one successful test with duration that is the sum of all flaky runs. 

### Investigation details

The alternative solution is to extend the junit format to account for flakiness and update all the systems that will use the new format.

### Decisions

The status of a flaky test group is "success". The duration of the test is reported as the sum of all runs of the flaky test.