### PR TITLE
[RA-1435] Read aab signature

### DIFF
--- a/androidsignature/signature.go
+++ b/androidsignature/signature.go
@@ -24,10 +24,11 @@ func Read(path string) (string, error) {
 	if strings.Contains(output, validSignatureMessage) {
 		// The signature details appear in the output in the following format:
 		// - Signed by "C=Aa, ST=Bbbbb, L=Ccccc, O=Ddddd, OU=Eeeee, CN=Fffff"
-		regex := regexp.MustCompile(`- Signed by "(.*?)"`)
-		matches := regex.FindStringSubmatch(output)
-		if len(matches) == 2 {
-			signature = matches[1]
+		regex := regexp.MustCompile(`- Signed by ".*"`)
+		sig := regex.FindString(output)
+		if sig != "" {
+			signature = strings.TrimPrefix(sig, "- Signed by \"")
+			signature = strings.TrimSuffix(signature, "\"")
 		}
 	}
 

--- a/androidsignature/signature.go
+++ b/androidsignature/signature.go
@@ -1,0 +1,40 @@
+package androidsignature
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/command"
+)
+
+const (
+	validSignatureMessage = "jar verified"
+)
+
+// Read ...
+func Read(path string) (string, error) {
+	cmd := signatureCheckCommand(path)
+	output, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	var signature string
+
+	if strings.Contains(output, validSignatureMessage) {
+		// The signature details appear in the output in the following format:
+		// - Signed by "C=Aa, ST=Bbbbb, L=Ccccc, O=Ddddd, OU=Eeeee, CN=Fffff"
+		regex := regexp.MustCompile(`- Signed by "(.*?)"`)
+		matches := regex.FindStringSubmatch(output)
+		if len(matches) == 2 {
+			signature = matches[1]
+		}
+	}
+
+	return signature, nil
+}
+
+func signatureCheckCommand(path string) *command.Model {
+	params := []string{"-verify", "-certs", "-verbose", path}
+	return command.New("jarsigner", params...)
+}

--- a/uploaders/aabuploader.go
+++ b/uploaders/aabuploader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/androidartifact"
+	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/androidsignature"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/bundletool"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
@@ -68,6 +69,12 @@ func DeployAAB(item deployment.DeployableItem, artifacts []string, buildURL, tok
 		"build_type":      info.BuildType,
 	}
 
+	signature, err := androidsignature.Read(pth)
+	if err != nil {
+		log.Errorf("Failed to read signature: %s", err)
+	}
+	aabInfoMap["signed_by"] = signature
+
 	splitMeta, err := androidartifact.CreateSplitArtifactMeta(pth, artifacts)
 	if err != nil {
 		log.Errorf("Failed to create split meta, error: %s", err)
@@ -77,7 +84,7 @@ func DeployAAB(item deployment.DeployableItem, artifacts []string, buildURL, tok
 		aabInfoMap["split"] = splitMeta.Split
 		aabInfoMap["universal"] = splitMeta.UniversalApk
 	}
-
+	
 	// ---
 
 	const AABContentType = "application/octet-stream aab"

--- a/uploaders/aabuploader.go
+++ b/uploaders/aabuploader.go
@@ -71,20 +71,20 @@ func DeployAAB(item deployment.DeployableItem, artifacts []string, buildURL, tok
 
 	signature, err := androidsignature.Read(pth)
 	if err != nil {
-		log.Errorf("Failed to read signature: %s", err)
+		log.Warnf("Failed to read signature: %s", err)
 	}
 	aabInfoMap["signed_by"] = signature
 
 	splitMeta, err := androidartifact.CreateSplitArtifactMeta(pth, artifacts)
 	if err != nil {
-		log.Errorf("Failed to create split meta, error: %s", err)
+		log.Warnf("Failed to create split meta, error: %s", err)
 	} else {
 		aabInfoMap["apk"] = splitMeta.APK
 		aabInfoMap["aab"] = splitMeta.AAB
 		aabInfoMap["split"] = splitMeta.Split
 		aabInfoMap["universal"] = splitMeta.UniversalApk
 	}
-	
+
 	// ---
 
 	const AABContentType = "application/octet-stream aab"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

The Release Automation team needs to differentiate between signed and unsigned aab files. At the moment such information is not included in the metadata file while the iOS counterpart has. 

### Changes

The Step extract the cretificate's DN value from aab. The signed aabs always have this while for the unsigned ones it will be empty. It uses the `jarsigner` tool for this which comes as part of the Android SDK.

The change is not covered with unit test because at the moment none of the metadata is tested. We have integration tests to upload the various supported files, unit tests for test result conversions to xml file and extensive tests for the test result handling. It is not clear how the metadata file can be downloaded as it is only used by the website. 
