### PR TITLE
Add parallel upload

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -152,6 +152,14 @@ workflows:
         - notify_email_list: $NOTIFY_EMAIL_LIST
         - is_enable_public_page: "true"
         - debug_mode: "true"
+    - script:
+        is_always_run: true
+        inputs:
+          - content: |-
+              #!/bin/bash
+              set -ex
+              # Force turn on the parallel uploads
+              envman add --key BITRISE_DEPLOY_UPLOAD_CONCURRENCY --value "10"
     - path::./:
         title: Many xml resources test
         run_if: true

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"html/template"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_generateUrlOutputWithTemplate(t *testing.T) {
@@ -89,6 +91,48 @@ func Test_generateUrlOutputWithTemplate(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("applyTemplateWithMaxSize() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestUploadConcurrency(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		want   int
+	}{
+		{
+			name: "Zero value",
+			config: Config{
+				UploadConcurrency: "0",
+			},
+			want: 1,
+		},
+		{
+			name: "Negative value",
+			config: Config{
+				UploadConcurrency: "-1",
+			},
+			want: 1,
+		},
+		{
+			name: "In range value",
+			config: Config{
+				UploadConcurrency: "3",
+			},
+			want: 3,
+		},
+		{
+			name: "Too large value",
+			config: Config{
+				UploadConcurrency: "100",
+			},
+			want: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, determineConcurrency(tt.config))
 		})
 	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

We discovered that uploading a large amount of assets with the steps takes too long. For example, uploading 1200 images takes approximately 15 minutes. This is because the step performs the upload item by item. Adding concurrency to the file uploads will make the step 8x faster. 

### Changes

The main change is that we can control the concurrency with the `BITRISE_DEPLOY_UPLOAD_CONCURRENCY` env var. This is needed because we want to experiment with what is ideal value for our systems. If the env var is missing then the step will use a concurrency of 1. Also at the moment we limit the max value to prevent the anything abusing this value. 

The second change is that the previous implementation was uploading the apks first then everything else. Now the apk upload is merged together with the everything else part.