### PR TITLE
Disable Zip64 extra field validation

### DIFF
--- a/bundletool/bundletool.go
+++ b/bundletool/bundletool.go
@@ -38,5 +38,5 @@ func fetchAny(source string, fallbackSources ...string) (Path, error) {
 
 // Command ...
 func (p Path) Command(cmd string, args ...string) *command.Model {
-	return command.New("java", append([]string{"-jar", string(p), cmd}, args...)...)
+	return command.New("java", append([]string{"-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-jar", string(p), cmd}, args...)...)
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The jdk has some regression which means 3rd party tools will face an error when working with apk, zip or jar files. The deploy step faces the same issue.

This is already fixed in newer jdk versions but we need time to update the stacks. Until then we need to live with this workaround. The build env team will clean it up once the newer Java versions are deployed.

### Changes

There is only a single extra parameter in the jar execution which disables the flawed field validation.