### PR TITLE
[CI-2284] Add configuration hash to the xml data

### DIFF
--- a/test/converters/xcresult3/action_test_summary.go
+++ b/test/converters/xcresult3/action_test_summary.go
@@ -1,5 +1,10 @@
 package xcresult3
 
+import (
+	"crypto/md5"
+	"encoding/hex"
+)
+
 // Attachment ...
 type Attachment struct {
 	Filename struct {
@@ -48,8 +53,26 @@ type FailureSummaries struct {
 	Values []ActionTestFailureSummary `json:"_values"`
 }
 
+// Configuration ...
+type Configuration struct {
+	Hash string
+}
+
+// UnmarshalJSON ...
+func (c *Configuration) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" || string(data) == `""` {
+		return nil
+	}
+
+	hash := md5.Sum(data)
+	c.Hash = hex.EncodeToString(hash[:])
+
+	return nil
+}
+
 // ActionTestSummary ...
 type ActionTestSummary struct {
 	ActivitySummaries ActivitySummaries `json:"activitySummaries"`
 	FailureSummaries  FailureSummaries  `json:"failureSummaries"`
+	Configuration     Configuration     `json:"configuration"`
 }

--- a/test/converters/xcresult3/action_test_summary_group.go
+++ b/test/converters/xcresult3/action_test_summary_group.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// ErrSummaryNotFound ...
+var ErrSummaryNotFound = errors.New("no summaryRef.ID.Value found for test case")
+
 // ActionTestSummaryGroup ...
 type ActionTestSummaryGroup struct {
 	Name       Name       `json:"name"`
@@ -73,7 +76,7 @@ func (g ActionTestSummaryGroup) testsWithStatus() (tests []ActionTestSummaryGrou
 // loadActionTestSummary ...
 func (g ActionTestSummaryGroup) loadActionTestSummary(xcresultPath string) (ActionTestSummary, error) {
 	if g.SummaryRef.ID.Value == "" {
-		return ActionTestSummary{}, errors.New("no summaryRef.ID.Value found for test case")
+		return ActionTestSummary{}, ErrSummaryNotFound
 	}
 
 	var summary ActionTestSummary

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -1,6 +1,7 @@
 package xcresult3
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -202,7 +203,11 @@ func genTestCase(test ActionTestSummaryGroup, xcresultPath, testResultDir string
 	}
 
 	testSummary, err := test.loadActionTestSummary(xcresultPath)
-	if err != nil {
+	// Ignoring the SummaryNotFoundError error is on purpose because not having an action summary is a valid use case.
+	// For example, failed tests will always have a summary, but successful ones might have it or might not.
+	// If they do not have it, then that means that they did not log anything to the console,
+	// and they were not executed as device configuration tests.
+	if err != nil && !errors.Is(err, ErrSummaryNotFound) {
 		return junit.TestCase{}, err
 	}
 

--- a/test/junit/xml.go
+++ b/test/junit/xml.go
@@ -24,14 +24,15 @@ type TestSuite struct {
 
 // TestCase ...
 type TestCase struct {
-	XMLName   xml.Name `xml:"testcase"`
-	Name      string   `xml:"name,attr"`
-	ClassName string   `xml:"classname,attr"`
-	Time      float64  `xml:"time,attr"`
-	Failure   *Failure `xml:"failure,omitempty"`
-	Skipped   *Skipped `xml:"skipped,omitempty"`
-	Error     *Error   `xml:"error,omitempty"`
-	SystemErr string   `xml:"system-err,omitempty"`
+	XMLName           xml.Name `xml:"testcase"`
+	ConfigurationHash string   `xml:"configuration-hash,attr"`
+	Name              string   `xml:"name,attr"`
+	ClassName         string   `xml:"classname,attr"`
+	Time              float64  `xml:"time,attr"`
+	Failure           *Failure `xml:"failure,omitempty"`
+	Skipped           *Skipped `xml:"skipped,omitempty"`
+	Error             *Error   `xml:"error,omitempty"`
+	SystemErr         string   `xml:"system-err,omitempty"`
 }
 
 // Failure ...

--- a/test/testdata/ios_device_config_xml_output.golden
+++ b/test/testdata/ios_device_config_xml_output.golden
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+ <testsuite name="DarkAndLightModeTests" tests="3" failures="1" skipped="0" errors="0" time="0.3750969171524048">
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.11242496967315674">
+   <failure>/Users/vagrant/git/DarkAndLightModeTests/DarkAndLightModeTests.swift:25 - failed - Reached 1</failure>
+  </testcase>
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.0011119842529296875"></testcase>
+  <testcase configuration-hash="" name="testPerformanceExample()" classname="DarkAndLightModeTests" time="0.26155996322631836"></testcase>
+ </testsuite>
+ <testsuite name="DarkAndLightModeUITests" tests="14" failures="12" skipped="0" errors="0" time="92.95631325244904">
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeUITests" time="3.8267470598220825"></testcase>
+  <testcase configuration-hash="" name="testLaunchPerformance()" classname="DarkAndLightModeUITests" time="28.429319024086"></testcase>
+  <testcase configuration-hash="16789993f7012553276a039f8829bcbf" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="7.017634034156799">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="16789993f7012553276a039f8829bcbf" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.156491994857788">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="16789993f7012553276a039f8829bcbf" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.570378065109253">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="bb9ffdfb3f0e2ac59b09a83bd8c1ba55" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="7.531908988952637">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="bb9ffdfb3f0e2ac59b09a83bd8c1ba55" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.387096047401428">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="bb9ffdfb3f0e2ac59b09a83bd8c1ba55" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.1682270765304565">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="990bacacade8f7dc5b2d9f4d042c3349" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="7.013818025588989">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="990bacacade8f7dc5b2d9f4d042c3349" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.297332048416138">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="990bacacade8f7dc5b2d9f4d042c3349" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.593717932701111">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="09150042f5350c48cdf9784faaa4b911" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.915426015853882">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="09150042f5350c48cdf9784faaa4b911" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.210652947425842">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+  <testcase configuration-hash="09150042f5350c48cdf9784faaa4b911" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="3.837563991546631">
+   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+  </testcase>
+ </testsuite>
+</testsuites>

--- a/test/testdata/ios_xml_output.golden
+++ b/test/testdata/ios_xml_output.golden
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
  <testsuite name="BitriseBasicUITest" tests="4" failures="0" skipped="0" errors="0" time="77.06086790561676">
-  <testcase name="testCollectionView()" classname="BitriseBasicUITest" time="23.776288986206055"></testcase>
-  <testcase name="testInReadTopView()" classname="BitriseBasicUITest" time="34.97628891468048"></testcase>
-  <testcase name="testInterstitialView()" classname="BitriseBasicUITest" time="10.270301938056946"></testcase>
-  <testcase name="testRewardView()" classname="BitriseBasicUITest" time="8.037988066673279"></testcase>
+  <testcase configuration-hash="" name="testCollectionView()" classname="BitriseBasicUITest" time="23.776288986206055"></testcase>
+  <testcase configuration-hash="" name="testInReadTopView()" classname="BitriseBasicUITest" time="34.97628891468048"></testcase>
+  <testcase configuration-hash="" name="testInterstitialView()" classname="BitriseBasicUITest" time="10.270301938056946"></testcase>
+  <testcase configuration-hash="" name="testRewardView()" classname="BitriseBasicUITest" time="8.037988066673279"></testcase>
  </testsuite>
  <testsuite name="BitriseCommanderUITests" tests="1" failures="0" skipped="1" errors="0" time="40.58690905570984">
-  <testcase name="testCommanderUpdate()" classname="BitriseCommanderUITests" time="40.58690905570984">
+  <testcase configuration-hash="" name="testCommanderUpdate()" classname="BitriseCommanderUITests" time="40.58690905570984">
    <skipped></skipped>
   </testcase>
  </testsuite>
  <testsuite name="BitriseComponentUITest" tests="2" failures="0" skipped="0" errors="0" time="33.92029893398285">
-  <testcase name="testAdChoiceIcon()" classname="BitriseComponentUITest" time="15.12886095046997"></testcase>
-  <testcase name="testFullScreenReplay()" classname="BitriseComponentUITest" time="18.79143798351288"></testcase>
+  <testcase configuration-hash="" name="testAdChoiceIcon()" classname="BitriseComponentUITest" time="15.12886095046997"></testcase>
+  <testcase configuration-hash="" name="testFullScreenReplay()" classname="BitriseComponentUITest" time="18.79143798351288"></testcase>
  </testsuite>
  <testsuite name="BitriseOMUITests" tests="3" failures="1" skipped="0" errors="0" time="80.687903881073">
-  <testcase name="testOMBanner()" classname="BitriseOMUITests" time="15.550718903541565">
+  <testcase configuration-hash="" name="testOMBanner()" classname="BitriseOMUITests" time="15.550718903541565">
    <failure>/Users/vagrant/git/BitriseApp/BitriseAppUITests/BitriseOMUITests.swift:70 - XCTAssertTrue failed - No session found</failure>
   </testcase>
-  <testcase name="testOMInterstitial()" classname="BitriseOMUITests" time="26.03164303302765"></testcase>
-  <testcase name="testOMScrollView()" classname="BitriseOMUITests" time="39.105541944503784"></testcase>
+  <testcase configuration-hash="" name="testOMInterstitial()" classname="BitriseOMUITests" time="26.03164303302765"></testcase>
+  <testcase configuration-hash="" name="testOMScrollView()" classname="BitriseOMUITests" time="39.105541944503784"></testcase>
  </testsuite>
  <testsuite name="BitriseTrackingsUITest" tests="2" failures="0" skipped="0" errors="0" time="28.362125039100647">
-  <testcase name="testTrackingsWithAd()" classname="BitriseTrackingsUITest" time="16.5611629486084"></testcase>
-  <testcase name="testTrackingsWithNoAd()" classname="BitriseTrackingsUITest" time="11.800962090492249"></testcase>
+  <testcase configuration-hash="" name="testTrackingsWithAd()" classname="BitriseTrackingsUITest" time="16.5611629486084"></testcase>
+  <testcase configuration-hash="" name="testTrackingsWithNoAd()" classname="BitriseTrackingsUITest" time="11.800962090492249"></testcase>
  </testsuite>
  <testsuite name="bitrErrorUITest" tests="9" failures="0" skipped="0" errors="0" time="152.8058191537857">
-  <testcase name="testbitrError403()" classname="bitrErrorUITest" time="16.062182068824768"></testcase>
-  <testcase name="testbitrError405()" classname="bitrErrorUITest" time="16.12081003189087"></testcase>
-  <testcase name="testbitrError901()" classname="bitrErrorUITest" time="16.46643900871277"></testcase>
-  <testcase name="testbitrError901_2()" classname="bitrErrorUITest" time="16.493804097175598"></testcase>
-  <testcase name="testbitrError901_3()" classname="bitrErrorUITest" time="16.023802995681763"></testcase>
-  <testcase name="testbitrError901_4()" classname="bitrErrorUITest" time="16.05063498020172"></testcase>
-  <testcase name="testbitrError901_5()" classname="bitrErrorUITest" time="16.06726598739624"></testcase>
-  <testcase name="testbitrVideoError402()" classname="bitrErrorUITest" time="23.205875992774963"></testcase>
-  <testcase name="testVpaidError401()" classname="bitrErrorUITest" time="16.315003991127014"></testcase>
+  <testcase configuration-hash="" name="testbitrError403()" classname="bitrErrorUITest" time="16.062182068824768"></testcase>
+  <testcase configuration-hash="" name="testbitrError405()" classname="bitrErrorUITest" time="16.12081003189087"></testcase>
+  <testcase configuration-hash="" name="testbitrError901()" classname="bitrErrorUITest" time="16.46643900871277"></testcase>
+  <testcase configuration-hash="" name="testbitrError901_2()" classname="bitrErrorUITest" time="16.493804097175598"></testcase>
+  <testcase configuration-hash="" name="testbitrError901_3()" classname="bitrErrorUITest" time="16.023802995681763"></testcase>
+  <testcase configuration-hash="" name="testbitrError901_4()" classname="bitrErrorUITest" time="16.05063498020172"></testcase>
+  <testcase configuration-hash="" name="testbitrError901_5()" classname="bitrErrorUITest" time="16.06726598739624"></testcase>
+  <testcase configuration-hash="" name="testbitrVideoError402()" classname="bitrErrorUITest" time="23.205875992774963"></testcase>
+  <testcase configuration-hash="" name="testVpaidError401()" classname="bitrErrorUITest" time="16.315003991127014"></testcase>
  </testsuite>
 </testsuites>

--- a/vendor/github.com/bitrise-io/go-utils/v2/command/command.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/command/command.go
@@ -1,0 +1,198 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+)
+
+// ErrorFinder ...
+type ErrorFinder func(out string) []string
+
+// Opts ...
+type Opts struct {
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Stdin       io.Reader
+	Env         []string
+	Dir         string
+	ErrorFinder ErrorFinder
+}
+
+// Factory ...
+type Factory interface {
+	Create(name string, args []string, opts *Opts) Command
+}
+
+type factory struct {
+	envRepository env.Repository
+}
+
+// NewFactory ...
+func NewFactory(envRepository env.Repository) Factory {
+	return factory{envRepository: envRepository}
+}
+
+// Create ...
+func (f factory) Create(name string, args []string, opts *Opts) Command {
+	cmd := exec.Command(name, args...)
+	var collector *errorCollector
+
+	if opts != nil {
+		if opts.ErrorFinder != nil {
+			collector = &errorCollector{errorFinder: opts.ErrorFinder}
+		}
+
+		cmd.Stdout = opts.Stdout
+		cmd.Stderr = opts.Stderr
+		cmd.Stdin = opts.Stdin
+
+		// If Env is nil, the new process uses the current process's
+		// environment.
+		// If we pass env vars we want to append them to the
+		// current process's environment.
+		cmd.Env = append(f.envRepository.List(), opts.Env...)
+		cmd.Dir = opts.Dir
+	}
+	return &command{
+		cmd:            cmd,
+		errorCollector: collector,
+	}
+}
+
+// Command ...
+type Command interface {
+	PrintableCommandArgs() string
+	Run() error
+	RunAndReturnExitCode() (int, error)
+	RunAndReturnTrimmedOutput() (string, error)
+	RunAndReturnTrimmedCombinedOutput() (string, error)
+	Start() error
+	Wait() error
+}
+
+type command struct {
+	cmd            *exec.Cmd
+	errorCollector *errorCollector
+}
+
+// PrintableCommandArgs ...
+func (c command) PrintableCommandArgs() string {
+	return printableCommandArgs(false, c.cmd.Args)
+}
+
+// Run ...
+func (c *command) Run() error {
+	c.wrapOutputs()
+
+	if err := c.cmd.Run(); err != nil {
+		return c.wrapError(err)
+	}
+
+	return nil
+}
+
+// RunAndReturnExitCode ...
+func (c command) RunAndReturnExitCode() (int, error) {
+	c.wrapOutputs()
+	err := c.cmd.Run()
+	if err != nil {
+		err = c.wrapError(err)
+	}
+
+	exitCode := c.cmd.ProcessState.ExitCode()
+	return exitCode, err
+}
+
+// RunAndReturnTrimmedOutput ...
+func (c command) RunAndReturnTrimmedOutput() (string, error) {
+	outBytes, err := c.cmd.Output()
+	outStr := string(outBytes)
+	if err != nil {
+		if c.errorCollector != nil {
+			c.errorCollector.collectErrors(outStr)
+		}
+		err = c.wrapError(err)
+	}
+
+	return strings.TrimSpace(outStr), err
+}
+
+// RunAndReturnTrimmedCombinedOutput ...
+func (c command) RunAndReturnTrimmedCombinedOutput() (string, error) {
+	outBytes, err := c.cmd.CombinedOutput()
+	outStr := string(outBytes)
+	if err != nil {
+		if c.errorCollector != nil {
+			c.errorCollector.collectErrors(outStr)
+		}
+		err = c.wrapError(err)
+	}
+
+	return strings.TrimSpace(outStr), err
+}
+
+// Start ...
+func (c command) Start() error {
+	c.wrapOutputs()
+	return c.cmd.Start()
+}
+
+// Wait ...
+func (c command) Wait() error {
+	err := c.cmd.Wait()
+	if err != nil {
+		err = c.wrapError(err)
+	}
+
+	return err
+}
+
+func printableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
+	var cmdArgsDecorated []string
+	for idx, anArg := range fullCommandArgs {
+		quotedArg := strconv.Quote(anArg)
+		if idx == 0 && !isQuoteFirst {
+			quotedArg = anArg
+		}
+		cmdArgsDecorated = append(cmdArgsDecorated, quotedArg)
+	}
+
+	return strings.Join(cmdArgsDecorated, " ")
+}
+
+func (c command) wrapError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if c.errorCollector != nil && len(c.errorCollector.errorLines) > 0 {
+			return fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New(strings.Join(c.errorCollector.errorLines, "\n")))
+		}
+		return fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New("check the command's output for details"))
+	}
+	return fmt.Errorf("executing command failed (%s): %w", c.PrintableCommandArgs(), err)
+}
+
+func (c command) wrapOutputs() {
+	if c.errorCollector == nil {
+		return
+	}
+
+	if c.cmd.Stdout != nil {
+		outWriter := io.MultiWriter(c.errorCollector, c.cmd.Stdout)
+		c.cmd.Stdout = outWriter
+	} else {
+		c.cmd.Stdout = c.errorCollector
+	}
+
+	if c.cmd.Stderr != nil {
+		errWriter := io.MultiWriter(c.errorCollector, c.cmd.Stderr)
+		c.cmd.Stderr = errWriter
+	} else {
+		c.cmd.Stderr = c.errorCollector
+	}
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/command/errorcollector.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/command/errorcollector.go
@@ -1,0 +1,18 @@
+package command
+
+type errorCollector struct {
+	errorLines  []string
+	errorFinder ErrorFinder
+}
+
+func (e *errorCollector) Write(p []byte) (n int, err error) {
+	e.collectErrors(string(p))
+	return len(p), nil
+}
+
+func (e *errorCollector) collectErrors(output string) {
+	lines := e.errorFinder(output)
+	if len(lines) > 0 {
+		e.errorLines = append(e.errorLines, lines...)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,6 +41,7 @@ github.com/bitrise-io/go-utils/urlutil
 github.com/bitrise-io/go-utils/ziputil
 # github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19
 ## explicit; go 1.17
+github.com/bitrise-io/go-utils/v2/command
 github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/errorutil
 github.com/bitrise-io/go-utils/v2/exitcode


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The generated xml data representation is not accurate for retried tests. These test runs appear as separate entries in the xml and we need to apply grouping/filtering logic to consume them. 

A simple logic is to simply use the test class name and test name. This works for the regular use cases but there is a new feature which breaks this which is the device configuration tests. This is a handy new Xcode feature where you can tell Xcode to launch the given tests on all language / orientation / interface mode combinations with:
```
override class var runsForEachTargetApplicationUIConfiguration: Bool {
    true
}
```
But tests launched like this will have the same name and identifier and only their configuration will be different. Xcode uses this configuration combo to uniquely identify them. The deploy step was not extracting these and now it will create a checksum from the configuration. 

The backend side grouping can then reliably identify and group related device configuration test runs.

Here is an example of a configuration object extracted from the xcresult file:
```
"configuration" : {
  "_type" : {
    "_name" : "ActionTestConfiguration"
  },
  "values" : {
    "_type" : {
      "_name" : "SortedKeyValueArray"
    },
    "storage" : {
      "_type" : {
        "_name" : "Array"
      },
      "_values" : [
        {
          "_type" : {
            "_name" : "SortedKeyValueArrayPair"
          },
          "key" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "XCUIAppearanceMode"
          },
          "value" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "1"
          }
        },
        {
          "_type" : {
            "_name" : "SortedKeyValueArrayPair"
          },
          "key" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "XCUIDeviceOrientation"
          },
          "value" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "1"
          }
        }
      ]
    }
  }
},
```

### Changes

There is a new `ConfigurationHash` field on the xml data struct. This field will be populated by a checksum of the actual configuration taken from the xcresult file.