### PR TITLE
Fix (MISSING) formatting errors due to unescaped printf usages

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 				errMessage += errorutil.FormattedError(err)
 			}
 
-			fail(errMessage)
+			fail("%s", errMessage)
 		}
 
 		log.Donef("Success")
@@ -314,7 +314,7 @@ func logDeployFiles(files []deployment.DeployableItem) {
 			message += " (pipeline intermediate file)"
 		}
 
-		log.Printf(message)
+		log.Printf("%s", message)
 	}
 }
 
@@ -507,7 +507,7 @@ func deploySingleItem(item deployment.DeployableItem, config Config, androidArti
 }
 
 func handleDeploymentFailureError(err error, errorCollection []error) []error {
-	log.Errorf(errorutil.FormattedError(err))
+	log.Errorf("%s", errorutil.FormattedError(err))
 	err = fmt.Errorf("deploy failed, error: %w", err)
 	errorCollection = append(errorCollection, err)
 	return errorCollection


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

A few maddening errors containing `%!v(MISSING)` appeared in the logs (likely a go format string was included in the upload URLs). Hopefully found them all, caused by bad printf usage.
```
deploy failed, error:
  failed to create file artifact: /[...]/noexisttest%!s(MISSING)%!v(MISSING):
    failed to get file size, error: file not exist at: /[...]/noexisttest%!s(MISSING)%!v(MISSING)
 ```
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
