### PR TITLE
Filter invalid reports

### DIFF
--- a/report/report_test.go
+++ b/report/report_test.go
@@ -13,6 +13,7 @@ import (
 	loggerV2 "github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/report/api"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/report/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,6 +42,28 @@ func TestFindsAndUploadsReports(t *testing.T) {
 	require.Equal(t, 0, len(uploadErrors))
 
 	mockClient.AssertExpectations(t)
+}
+
+func TestInvalidReportFiltering(t *testing.T) {
+	reportDir, reports := createReports(t)
+	uploader := HTMLReportUploader{
+		client:      nil,
+		logger:      loggerV2.NewLogger(),
+		reportDir:   reportDir,
+		concurrency: 1,
+	}
+
+	// Create an invalid report
+	reports[0].Assets = reports[0].Assets[:2]
+
+	validatedReports, validatedErrors := uploader.validate(reports)
+
+	expectedErrors := []error{
+		fmt.Errorf("missing index.html file for Test A"),
+		fmt.Errorf("missing index.html file for Test B"),
+	}
+	assert.Equal(t, expectedErrors, validatedErrors)
+	assert.Equal(t, len(validatedReports), 2)
 }
 
 // createReports creates dummy data for multiple test reports.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

At the moment the step and backend does not do any validation if the html report is valid or not. We have only one requirement which is that a report has to have an `index.html` file as its entry point. As a first step this validation is added to the step. 