### PR TITLE
Set content type for known extensions

### DIFF
--- a/report/collect.go
+++ b/report/collect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -121,12 +122,10 @@ func overrideContentTypeForKnownExtensions(extension, contentType string) string
 		return contentType
 	}
 
-	switch extension {
-	case ".js":
-		return strings.ReplaceAll(contentType, plainContentType, "text/javascript")
-	case ".css":
-		return strings.ReplaceAll(contentType, plainContentType, "text/css")
-	default:
-		return contentType
+	newContentType := mime.TypeByExtension(extension)
+	if newContentType != "" {
+		return newContentType
 	}
+
+	return contentType
 }

--- a/report/collect_test.go
+++ b/report/collect_test.go
@@ -1,0 +1,45 @@
+package report
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecialContentTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		expected string
+	}{
+		{
+			name:     "Plain text file",
+			fileName: "abc.txt",
+			expected: "text/plain; charset=utf-8",
+		},
+		{
+			name:     "Javascript file",
+			fileName: "abc.js",
+			expected: "text/javascript; charset=utf-8",
+		},
+		{
+			name:     "CSS file",
+			fileName: "abc.css",
+			expected: "text/css; charset=utf-8",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), test.fileName)
+			err := os.WriteFile(path, []byte("hello world"), 0644)
+			require.NoError(t, err)
+
+			contentType := detectContentType(path)
+			assert.Equal(t, test.expected, contentType)
+		})
+	}
+}

--- a/report/collect_test.go
+++ b/report/collect_test.go
@@ -23,7 +23,7 @@ func TestSpecialContentTypes(t *testing.T) {
 		{
 			name:     "Javascript file",
 			fileName: "abc.js",
-			expected: "text/javascript; charset=utf-8",
+			expected: "application/javascript",
 		},
 		{
 			name:     "CSS file",

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Smallest valid base64 encoded image data which returns a correct content type.
 const (
+	// Smallest valid base64 encoded image data which returns a correct content type.
 	pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg=="
 	jpgBase64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////wgALCAABAAEBAREA/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPxA="
+	// Smallest valid html code
+	html = "<!doctype html><meta charset=utf-8><title>shortest html5</title>"
 )
 
 func TestFindsAndUploadsReports(t *testing.T) {
@@ -86,7 +88,7 @@ func createReports(t *testing.T) (string, []Report) {
 				},
 				{
 					"name": "index.html",
-					"size": "1",
+					"size": "64",
 					"type": "text/html; charset=utf-8",
 				},
 			},
@@ -100,7 +102,7 @@ func createReports(t *testing.T) (string, []Report) {
 			"assets": []map[string]string{
 				{
 					"name": "index.html",
-					"size": "1",
+					"size": "64",
 					"type": "text/html; charset=utf-8",
 				},
 			},
@@ -113,7 +115,7 @@ func createReports(t *testing.T) (string, []Report) {
 			"assets": []map[string]string{
 				{
 					"name": "index.html",
-					"size": "1",
+					"size": "64",
 					"type": "text/html; charset=utf-8",
 				},
 			},
@@ -153,6 +155,8 @@ func createReports(t *testing.T) (string, []Report) {
 				require.NoError(t, err)
 
 				bytes = decoded
+			} else if strings.HasSuffix(assetName, ".html") {
+				bytes = []byte(html)
 			} else {
 				bytes = []byte("a")
 			}

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -87,7 +87,7 @@ func createReports(t *testing.T) (string, []Report) {
 				{
 					"name": "index.html",
 					"size": "1",
-					"type": "text/plain; charset=utf-8",
+					"type": "text/html; charset=utf-8",
 				},
 			},
 		},
@@ -101,7 +101,7 @@ func createReports(t *testing.T) (string, []Report) {
 				{
 					"name": "index.html",
 					"size": "1",
-					"type": "text/plain; charset=utf-8",
+					"type": "text/html; charset=utf-8",
 				},
 			},
 		},
@@ -114,7 +114,7 @@ func createReports(t *testing.T) (string, []Report) {
 				{
 					"name": "index.html",
 					"size": "1",
-					"type": "text/plain; charset=utf-8",
+					"type": "text/html; charset=utf-8",
 				},
 			},
 		},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The uploaded html reports could not load the css and js files because they were upload with an incorrect `text/plain` content type. This PR sets correct content type for them.