### PR TITLE
Deploy the snapshot of generic files under 1GB file size

### DIFF
--- a/main.go
+++ b/main.go
@@ -544,8 +544,6 @@ func deploySingleItem(item deployment.DeployableItem, config Config, androidArti
 
 		return uploaders.DeployXcarchive(item, config.BuildURL, config.APIToken)
 	default:
-		logger.Printf("Deploying file: %s", pth)
-
 		return uploaders.DeployFile(item, config.BuildURL, config.APIToken)
 	}
 }

--- a/uploaders/fileuploader.go
+++ b/uploaders/fileuploader.go
@@ -40,7 +40,7 @@ func DeployFile(item deployment.DeployableItem, buildURL, token string) (Artifac
 	}
 
 	if deploySnapshot {
-		log.Printf("Deploying file snapshot: %s", pth)
+		log.Printf("Deploying snapshot of original file: %s", pth)
 	} else {
 		log.Printf("Deploying file: %s", pth)
 	}

--- a/uploaders/fileuploader.go
+++ b/uploaders/fileuploader.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
-
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
 
@@ -22,6 +21,8 @@ func DeployFile(item deployment.DeployableItem, buildURL, token string) (Artifac
 		return ArtifactURLs{}, fmt.Errorf("get file size: %w", err)
 	}
 
+	// TODO: This is a workaround to avoid uploading a file that is being modified during the upload process,
+	//  which can cause an issue like: request body larger than specified content length at file upload.
 	if fileSize <= snapshotFileSizeLimitInBytes {
 		snapshotPth, err := createSnapshot(pth)
 		if err != nil {

--- a/uploaders/fileuploader.go
+++ b/uploaders/fileuploader.go
@@ -23,6 +23,7 @@ func DeployFile(item deployment.DeployableItem, buildURL, token string) (Artifac
 
 	// TODO: This is a workaround to avoid uploading a file that is being modified during the upload process,
 	//  which can cause an issue like: request body larger than specified content length at file upload.
+	deploySnapshot := false
 	if fileSize <= snapshotFileSizeLimitInBytes {
 		snapshotPth, err := createSnapshot(pth)
 		if err != nil {
@@ -34,7 +35,14 @@ func DeployFile(item deployment.DeployableItem, buildURL, token string) (Artifac
 				}
 			}()
 			pth = snapshotPth
+			deploySnapshot = true
 		}
+	}
+
+	if deploySnapshot {
+		log.Printf("Deploying file snapshot: %s", pth)
+	} else {
+		log.Printf("Deploying file: %s", pth)
 	}
 
 	artifact := ArtifactArgs{


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR implements a workaround for deploying generic files, that are potentially being modified during the deployment process.
The workaround is creating a snapshot of generic files at max 1GB file size, by copying them to a tmp path and deploying this tmp file, instead of the original file.
