### PR TITLE
[CI-4420] New test result extraction

### DIFF
--- a/report/collect_test.go
+++ b/report/collect_test.go
@@ -23,7 +23,7 @@ func TestSpecialContentTypes(t *testing.T) {
 		{
 			name:     "Javascript file",
 			fileName: "abc.js",
-			expected: "application/javascript",
+			expected: "text/javascript; charset=utf-8",
 		},
 		{
 			name:     "CSS file",

--- a/test/converters/converters_test.go
+++ b/test/converters/converters_test.go
@@ -27,17 +27,17 @@ func TestXCresult3Converters(t *testing.T) {
 				Tests:    2,
 				Failures: 0,
 				Errors:   0,
-				Time:     0.26388001441955566,
+				Time:     0.26063,
 				TestCases: []junit.TestCase{
 					{ // plain test case
 						Name:      "testExample()",
 						ClassName: "rtgtrghtrgTests",
-						Time:      0.0006339550018310547,
+						Time:      0.00063,
 					},
 					{ // plain test case
 						Name:      "testPerformanceExample()",
 						ClassName: "rtgtrghtrgTests",
-						Time:      0.2632460594177246,
+						Time:      0.26,
 					},
 				},
 			},
@@ -46,98 +46,98 @@ func TestXCresult3Converters(t *testing.T) {
 				Tests:    15,
 				Failures: 3,
 				Errors:   0,
-				Time:     0.7596049308776855,
+				Time:     0.759,
 				TestCases: []junit.TestCase{
 					// class rtgtrghtrg3UITests: XCTestCase inside rtgtrghtrgUITests class
 					{
 						Name:      "testExample",
 						ClassName: "_TtCC17rtgtrghtrgUITests17rtgtrghtrgUITests18rtgtrghtrg3UITests",
-						Time:      0.031695008277893066,
+						Time:      0.032,
 					},
 					{
 						Name:      "testFailMe",
 						ClassName: "_TtCC17rtgtrghtrgUITests17rtgtrghtrgUITests18rtgtrghtrg3UITests",
-						Time:      0.09049093723297119,
+						Time:      0.09,
 						Failure: &junit.Failure{
-							Value: "/Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:68 - XCTAssertTrue failed",
+							Value: "XCTAssertTrue failed",
 						},
 					},
 					{
 						Name:      "testLaunchPerformance",
 						ClassName: "_TtCC17rtgtrghtrgUITests17rtgtrghtrgUITests18rtgtrghtrg3UITests",
-						Time:      0.036438941955566406,
+						Time:      0.036,
 					},
 
 					// class rtgtrghtrg2UITests: XCTestCase
 					{
 						Name:      "testExample()",
 						ClassName: "rtgtrghtrg2UITests",
-						Time:      0.06093001365661621,
+						Time:      0.061,
 					},
 					{
 						Name:      "testFailMe()",
 						ClassName: "rtgtrghtrg2UITests",
-						Time:      0.08525991439819336,
+						Time:      0.085,
 						Failure: &junit.Failure{
-							Value: "/Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:105 - XCTAssertTrue failed",
+							Value: "XCTAssertTrue failed",
 						},
 					},
 					{
 						Name:      "testLaunchPerformance()",
 						ClassName: "rtgtrghtrg2UITests",
-						Time:      0.041545987129211426,
+						Time:      0.042,
 					},
 
 					// class rtgtrghtrg4UITests: rtgtrghtrgUITests (so rtgtrghtrg4UITests inherits rtgtrghtrgUITests -> test cases merged and the base class name is rtgtrghtrg4UITests)
 					{
 						Name:      "testExample()",
 						ClassName: "rtgtrghtrg4UITests",
-						Time:      0.07126104831695557,
+						Time:      0.071,
 					},
 					{
 						Name:      "testExample2()",
 						ClassName: "rtgtrghtrg4UITests",
-						Time:      0.043392062187194824,
+						Time:      0.043,
 					},
 					{
 						Name:      "testFailMe()",
 						ClassName: "rtgtrghtrg4UITests",
-						Time:      0.04290807247161865,
+						Time:      0.043,
 					},
 					{
 						Name:      "testFailMe2()",
 						ClassName: "rtgtrghtrg4UITests",
-						Time:      0.08395206928253174,
+						Time:      0.084,
 						Failure: &junit.Failure{
-							Value: "/Users/tamaspapik/Develop/ios/rtgtrghtrg/rtgtrghtrgUITests/rtgtrghtrgUITests.swift:130 - XCTAssertTrue failed",
+							Value: "XCTAssertTrue failed",
 						},
 					},
 					{
 						Name:      "testLaunchPerformance()",
 						ClassName: "rtgtrghtrg4UITests",
-						Time:      0.048184990882873535,
+						Time:      0.048,
 					},
 					{
 						Name:      "testLaunchPerformance2()",
 						ClassName: "rtgtrghtrg4UITests",
-						Time:      0.030627012252807617,
+						Time:      0.031,
 					},
 
 					// class rtgtrghtrgUITests: XCTestCase
 					{
 						Name:      "testExample()",
 						ClassName: "rtgtrghtrgUITests",
-						Time:      0.030849933624267578,
+						Time:      0.031,
 					},
 					{
 						Name:      "testFailMe()",
 						ClassName: "rtgtrghtrgUITests",
-						Time:      0.030683040618896484,
+						Time:      0.031,
 					},
 					{
 						Name:      "testLaunchPerformance()",
 						ClassName: "rtgtrghtrgUITests",
-						Time:      0.03138589859008789,
+						Time:      0.031,
 					},
 				},
 			},

--- a/test/converters/xcresult3/action_test_summary_group.go
+++ b/test/converters/xcresult3/action_test_summary_group.go
@@ -74,20 +74,20 @@ func (g ActionTestSummaryGroup) testsWithStatus() (tests []ActionTestSummaryGrou
 }
 
 // loadActionTestSummary ...
-func (g ActionTestSummaryGroup) loadActionTestSummary(xcresultPath string) (ActionTestSummary, error) {
+func (g ActionTestSummaryGroup) loadActionTestSummary(xcresultPath string, useLegacyFlag bool) (ActionTestSummary, error) {
 	if g.SummaryRef.ID.Value == "" {
 		return ActionTestSummary{}, ErrSummaryNotFound
 	}
 
 	var summary ActionTestSummary
-	if err := xcresulttoolGet(xcresultPath, g.SummaryRef.ID.Value, &summary); err != nil {
+	if err := xcresulttoolGet(xcresultPath, g.SummaryRef.ID.Value, useLegacyFlag, &summary); err != nil {
 		return ActionTestSummary{}, fmt.Errorf("failed to load ActionTestSummary: %w", err)
 	}
 	return summary, nil
 }
 
 // exportScreenshots ...
-func (g ActionTestSummaryGroup) exportScreenshots(resultPth, outputDir string) error {
+func (g ActionTestSummaryGroup) exportScreenshots(resultPth, outputDir string, useLegacyFlag bool) error {
 	if g.TestStatus.Value == "" {
 		return nil
 	}
@@ -97,7 +97,7 @@ func (g ActionTestSummaryGroup) exportScreenshots(resultPth, outputDir string) e
 	}
 
 	var summary ActionTestSummary
-	if err := xcresulttoolGet(resultPth, g.SummaryRef.ID.Value, &summary); err != nil {
+	if err := xcresulttoolGet(resultPth, g.SummaryRef.ID.Value, useLegacyFlag, &summary); err != nil {
 		return err
 	}
 
@@ -110,7 +110,7 @@ func (g ActionTestSummaryGroup) exportScreenshots(resultPth, outputDir string) e
 				}
 
 				pth := filepath.Join(outputDir, value.Filename.Value)
-				if err := xcresulttoolExport(resultPth, value.PayloadRef.ID.Value, pth); err != nil {
+				if err := xcresulttoolExport(resultPth, value.PayloadRef.ID.Value, pth, useLegacyFlag); err != nil {
 					return err
 				}
 				exported[value.PayloadRef.ID.Value] = true

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -169,9 +169,13 @@ func parse(path string) (junit.XML, error) {
 		return junit.XML{}, err
 	}
 
-	testSummary, err := model3.Convert(results)
+	testSummary, warnings, err := model3.Convert(results)
 	if err != nil {
 		return junit.XML{}, err
+	}
+
+	if len(warnings) > 0 {
+		logWarn("xcresults3-data", nil, fmt.Sprintf("warnings: %s", warnings))
 	}
 
 	var xml junit.XML

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -112,7 +112,7 @@ func (c *Converter) XML() (junit.XML, error) {
 		log.Warnf(fmt.Sprintf("Failed to parse extraction method: %s", err))
 		log.Warnf("Falling back to legacy extraction method")
 
-		logWarn("xcresult3-parsing", nil, "error: %s", err)
+		sendRemoteWarning("xcresult3-parsing", "error: %s", err)
 
 		useLegacyFlag = true
 	}
@@ -174,7 +174,7 @@ func parse(path string) (junit.XML, error) {
 	}
 
 	if len(warnings) > 0 {
-		logWarn("xcresults3-data", nil, "warnings: %s", warnings)
+		sendRemoteWarning("xcresults3-data", "warnings: %s", warnings)
 	}
 
 	var xml junit.XML

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -170,7 +170,6 @@ func parse(path string) (junit.XML, error) {
 	}
 
 	outputPath := filepath.Dir(path)
-	//outputPath := "/Users/szabi/Downloads/Net/xcresult/own/attachments"
 	if err := exportAttachments(path, outputPath); err != nil {
 		return junit.XML{}, err
 	}
@@ -244,7 +243,7 @@ func exportAttachments(xcresultPath, outputPath string) error {
 			}
 		}
 	}
-	
+
 	if err := os.Remove(manifestPath); err != nil {
 		return err
 	}

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -233,6 +233,10 @@ func exportAttachments(xcresultPath, outputPath string) error {
 		return err
 	}
 
+	return renameFiles(outputPath)
+}
+
+func renameFiles(outputPath string) error {
 	manifestPath := filepath.Join(outputPath, "manifest.json")
 	bytes, err := os.ReadFile(manifestPath)
 	if err != nil {

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -109,11 +109,10 @@ func (c *Converter) XML() (junit.XML, error) {
 			return junitXml, nil
 		}
 
-		errorMessage := fmt.Sprintf("Failed to parse extraction method: %s", err)
-		log.Warnf(errorMessage)
+		log.Warnf(fmt.Sprintf("Failed to parse extraction method: %s", err))
 		log.Warnf("Falling back to legacy extraction method")
 
-		logWarn("xcresult3-parsing", nil, errorMessage)
+		logWarn("xcresult3-parsing", nil, "error: %s", err)
 
 		useLegacyFlag = true
 	}
@@ -175,7 +174,7 @@ func parse(path string) (junit.XML, error) {
 	}
 
 	if len(warnings) > 0 {
-		logWarn("xcresults3-data", nil, fmt.Sprintf("warnings: %s", warnings))
+		logWarn("xcresults3-data", nil, "warnings: %s", warnings)
 	}
 
 	var xml junit.XML

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -47,66 +47,60 @@ func TestConverter_XML(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []junit.TestSuite{
 			{
-				Name: "BullsEyeTests", Tests: 5, Failures: 0, Skipped: 0, Errors: 0, Time: 0.9777920246124268,
+				Name: "BullsEyeTests", Tests: 5, Failures: 0, Skipped: 0, Errors: 0, Time: 0.9774,
 				TestCases: []junit.TestCase{
 					{
 						Name: "testStartNewRoundUsesRandomValueFromApiRequest()", ClassName: "BullsEyeFakeTests",
-						Time: 0.014459013938903809,
+						Time: 0.014,
 					},
 					{
 						Name: "testGameStyleCanBeChanged()", ClassName: "BullsEyeMockTests",
-						Time: 0.00929105281829834,
+						Time: 0.0093,
 					},
 					{
 						Name: "testScoreIsComputedPerformance()", ClassName: "BullsEyeTests",
-						Time: 0.7373920679092407,
+						Time: 0.74,
 					},
 					{
 						Name: "testScoreIsComputedWhenGuessIsHigherThanTarget()", ClassName: "BullsEyeTests",
-						Time: 0.004113912582397461,
+						Time: 0.0041,
 					},
 					{
 						Name: "testScoreIsComputedWhenGuessIsLowerThanTarget()", ClassName: "BullsEyeTests",
-						Time: 0.21253597736358643,
+						Time: 0.21,
 					},
 				},
 			},
 			{
-				Name: "BullsEyeSlowTests", Tests: 2, Failures: 0, Skipped: 0, Errors: 0, Time: 0.5334550142288208,
+				Name: "BullsEyeSlowTests", Tests: 2, Failures: 0, Skipped: 0, Errors: 0, Time: 0.53,
 				TestCases: []junit.TestCase{
 					{
 						Name: "testApiCallCompletes()", ClassName: "BullsEyeSlowTests",
-						Time: 0.2844870090484619,
+						Time: 0.28,
 					},
 					{
 						Name: "testValidApiCallGetsHTTPStatusCode200()", ClassName: "BullsEyeSlowTests",
-						Time: 0.2489680051803589,
+						Time: 0.25,
 					},
 				},
 			},
 			{
-				Name: "BullsEyeUITests", Tests: 1, Failures: 0, Skipped: 0, Errors: 0, Time: 9.606701016426086,
+				Name: "BullsEyeUITests", Tests: 1, Failures: 0, Skipped: 0, Errors: 0, Time: 9,
 				TestCases: []junit.TestCase{
 					{
 						Name: "testGameStyleSwitch()", ClassName: "BullsEyeUITests",
-						Time: 9.606701016426086,
+						Time: 9,
 					},
 				},
 			},
 			{ // testFlakyFeature() was flaky: failed once, and then passed the second run
-				Name: "BullsEyeFlakyTests", Tests: 3, Failures: 1, Skipped: 1, Errors: 0, Time: 0.22202682495117188,
+				Name: "BullsEyeFlakyTests", Tests: 2, Failures: 0, Skipped: 1, Errors: 0, Time: 0.12,
 				TestCases: []junit.TestCase{
 					{
-						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.1958599090576172,
-						Failure: &junit.Failure{
-							Value: "/Users/vagrant/git/BullsEyeFlakyTests/BullsEyeFlakyTests.swift:43 - XCTAssertEqual failed: (\"1\") is not equal to (\"0\") - Number is not even",
-						},
+						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.1,
 					},
 					{
-						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.00603795051574707,
-					},
-					{
-						Name: "testFlakySkip()", ClassName: "BullsEyeSkippedTests", Time: 0.020128965377807617,
+						Name: "testFlakySkip()", ClassName: "BullsEyeSkippedTests", Time: 0.02,
 						Skipped: &junit.Skipped{},
 					},
 				},
@@ -138,26 +132,26 @@ func TestConverter_XML(t *testing.T) {
 				Failures: 1,
 				Skipped:  1,
 				Errors:   0,
-				Time:     0.43262600898742676,
+				Time:     0.435,
 				TestCases: []junit.TestCase{
 					{
 						Name:      "testFailure()",
 						ClassName: "testProjectUITests",
-						Time:      0.2580660581588745,
+						Time:      0.26,
 						Failure: &junit.Failure{
-							Value: "/Users/alexeysomov/Library/Autosave Information/testProject/testProjectUITests/testProjectUITests.swift:30 - XCTAssertTrue failed",
+							Value: "testProjectUITests.swift:30: XCTAssertTrue failed",
 						},
 					},
 					{
 						Name:      "testSkip()",
 						ClassName: "testProjectUITests",
-						Time:      0.08595001697540283,
+						Time:      0.086,
 						Skipped:   &junit.Skipped{},
 					},
 					{
 						Name:      "testSuccess()",
 						ClassName: "testProjectUITests",
-						Time:      0.08860993385314941,
+						Time:      0.089,
 					},
 				},
 			},

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -93,7 +93,7 @@ func TestConverter_XML(t *testing.T) {
 					},
 				},
 			},
-			{ // testFlakyFeature() was flaky: failed once, and then passed the second run
+			{
 				Name: "BullsEyeFlakyTests", Tests: 2, Failures: 0, Skipped: 1, Errors: 0, Time: 0.12,
 				TestCases: []junit.TestCase{
 					{

--- a/test/converters/xcresult3/logging.go
+++ b/test/converters/xcresult3/logging.go
@@ -1,0 +1,15 @@
+package xcresult3
+
+import "github.com/bitrise-io/go-utils/log"
+
+func initData(data map[string]interface{}) map[string]interface{} {
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+	data["source"] = "deploy-to-bitrise-io"
+	return data
+}
+
+func logWarn(tag string, data map[string]interface{}, format string, v ...interface{}) {
+	log.RWarnf("deploy-to-bitrise-io", tag, initData(data), format, v...)
+}

--- a/test/converters/xcresult3/logging.go
+++ b/test/converters/xcresult3/logging.go
@@ -2,14 +2,9 @@ package xcresult3
 
 import "github.com/bitrise-io/go-utils/log"
 
-func initData(data map[string]interface{}) map[string]interface{} {
-	if data == nil {
-		data = map[string]interface{}{}
-	}
+func sendRemoteWarning(tag string, format string, v ...interface{}) {
+	data := map[string]interface{}{}
 	data["source"] = "deploy-to-bitrise-io"
-	return data
-}
 
-func logWarn(tag string, data map[string]interface{}, format string, v ...interface{}) {
-	log.RWarnf("deploy-to-bitrise-io", tag, initData(data), format, v...)
+	log.RWarnf("deploy-to-bitrise-io", tag, data, format, v...)
 }

--- a/test/converters/xcresult3/model3/conversion.go
+++ b/test/converters/xcresult3/model3/conversion.go
@@ -6,33 +6,34 @@ import (
 	"time"
 )
 
-func Convert(data *TestData) (*TestSummary, error) {
+func Convert(data *TestData) (*TestSummary, []string, error) {
+	var warnings []string
 	summary := TestSummary{}
 
 	for _, testPlanNode := range data.TestNodes {
 		if testPlanNode.Type != TestNodeTypeTestPlan {
-			return nil, fmt.Errorf("test plan expected but got: %s", testPlanNode.Type)
+			return nil, warnings, fmt.Errorf("test plan expected but got: %s", testPlanNode.Type)
 		}
 
 		testPlan := TestPlan{Name: testPlanNode.Name}
 
 		for _, testBundleNode := range testPlanNode.Children {
 			if testBundleNode.Type != TestNodeTypeUnitTestBundle && testBundleNode.Type != TestNodeTypeUITestBundle {
-				return nil, fmt.Errorf("test bundle expected but got: %s", testBundleNode.Type)
+				return nil, warnings, fmt.Errorf("test bundle expected but got: %s", testBundleNode.Type)
 			}
 
 			testBundle := TestBundle{Name: testBundleNode.Name}
 
 			for _, testSuiteNode := range testBundleNode.Children {
 				if testSuiteNode.Type != TestNodeTypeTestSuite {
-					return nil, fmt.Errorf("test suite expected but got: %s", testSuiteNode.Type)
+					return nil, warnings, fmt.Errorf("test suite expected but got: %s", testSuiteNode.Type)
 				}
 
 				testSuite := TestSuite{Name: testSuiteNode.Name}
 
 				for _, testCaseNode := range testSuiteNode.Children {
 					if testCaseNode.Type != TestNodeTypeTestCase {
-						return nil, fmt.Errorf("test case expected but got: %s", testCaseNode.Type)
+						return nil, warnings, fmt.Errorf("test case expected but got: %s", testCaseNode.Type)
 					}
 
 					className := strings.Split(testCaseNode.Identifier, "/")[0]
@@ -42,12 +43,18 @@ func Convert(data *TestData) (*TestSummary, error) {
 						className = testSuiteNode.Name
 					}
 
+					message, failureMessageWarnings := extractFailureMessage(testCaseNode)
+
+					if len(failureMessageWarnings) > 0 {
+						warnings = append(warnings, failureMessageWarnings...)
+					}
+
 					testCase := TestCase{
 						Name:      testCaseNode.Name,
 						ClassName: className,
 						Time:      extractDuration(testCaseNode.Duration),
 						Result:    testCaseNode.Result,
-						Message:   extractFailureMessage(testCaseNode),
+						Message:   message,
 					}
 					testSuite.TestCases = append(testSuite.TestCases, testCase)
 				}
@@ -61,7 +68,7 @@ func Convert(data *TestData) (*TestSummary, error) {
 		summary.TestPlans = append(summary.TestPlans, testPlan)
 	}
 
-	return &summary, nil
+	return &summary, warnings, nil
 }
 
 func extractDuration(text string) time.Duration {
@@ -74,10 +81,10 @@ func extractDuration(text string) time.Duration {
 	return duration
 }
 
-func extractFailureMessage(testNode TestNode) string {
+func extractFailureMessage(testNode TestNode) (string, []string) {
 	childrenCount := len(testNode.Children)
 	if childrenCount == 0 {
-		return ""
+		return "", nil
 	}
 
 	lastNode := testNode.Children[childrenCount-1]
@@ -85,14 +92,22 @@ func extractFailureMessage(testNode TestNode) string {
 		return extractFailureMessage(lastNode)
 	}
 
+	var warnings []string
 	failureMessage := ""
 
 	for _, child := range testNode.Children {
 		if child.Type == TestNodeTypeFailureMessage {
 			// The failure message appears in the Name field and not in the Details field.
+			if child.Name == "" {
+				warnings = append(warnings, fmt.Sprintf("'%s' type has empty name field", child.Type))
+			}
+			if child.Details != "" {
+				warnings = append(warnings, fmt.Sprintf("'%s' type has unexpected details field", child.Type))
+			}
+
 			failureMessage += child.Name
 		}
 	}
 
-	return failureMessage
+	return failureMessage, warnings
 }

--- a/test/converters/xcresult3/model3/conversion.go
+++ b/test/converters/xcresult3/model3/conversion.go
@@ -1,0 +1,91 @@
+package model3
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func Convert(data *TestData) (*TestSummary, error) {
+	summary := TestSummary{}
+
+	for _, testPlanNode := range data.TestNodes {
+		if testPlanNode.Type != TestNodeTypeTestPlan {
+			return nil, fmt.Errorf("test plan expected but got: %s", testPlanNode.Type)
+		}
+
+		testPlan := TestPlan{Name: testPlanNode.Name}
+
+		for _, testBundleNode := range testPlanNode.Children {
+			if testBundleNode.Type != TestNodeTypeUnitTestBundle && testBundleNode.Type != TestNodeTypeUITestBundle {
+				return nil, fmt.Errorf("test bundle expected but got: %s", testBundleNode.Type)
+			}
+
+			testBundle := TestBundle{Name: testBundleNode.Name}
+
+			for _, testSuiteNode := range testBundleNode.Children {
+				if testSuiteNode.Type != TestNodeTypeTestSuite {
+					return nil, fmt.Errorf("test suite expected but got: %s", testSuiteNode.Type)
+				}
+
+				testSuite := TestSuite{Name: testSuiteNode.Name}
+
+				for _, testCaseNode := range testSuiteNode.Children {
+					if testCaseNode.Type != TestNodeTypeTestCase {
+						return nil, fmt.Errorf("test case expected but got: %s", testCaseNode.Type)
+					}
+
+					testCase := TestCase{
+						Name:      testCaseNode.Name,
+						ClassName: strings.Split(testCaseNode.Identifier, "/")[0],
+						Time:      extractDuration(testCaseNode.Duration),
+						Result:    testCaseNode.Result,
+						Message:   extractFailureMessage(testCaseNode),
+					}
+					testSuite.TestCases = append(testSuite.TestCases, testCase)
+				}
+
+				testBundle.TestSuites = append(testBundle.TestSuites, testSuite)
+			}
+
+			testPlan.TestBundles = append(testPlan.TestBundles, testBundle)
+		}
+
+		summary.TestPlans = append(summary.TestPlans, testPlan)
+	}
+
+	return &summary, nil
+}
+
+func extractDuration(text string) time.Duration {
+	// Duration is in the format "123.456789s"
+	duration, err := time.ParseDuration(text)
+	if err != nil {
+		return 0
+	}
+
+	return duration
+}
+
+func extractFailureMessage(testNode TestNode) string {
+	childrenCount := len(testNode.Children)
+	if childrenCount == 0 {
+		return ""
+	}
+
+	lastNode := testNode.Children[childrenCount-1]
+	if lastNode.Type == TestNodeTypeRepetition {
+		return extractFailureMessage(lastNode)
+	}
+
+	failureMessage := ""
+
+	for _, child := range testNode.Children {
+		if child.Type == TestNodeTypeFailureMessage {
+			// The failure message appears in the Name field and not in the Details field.
+			failureMessage += child.Name
+		}
+	}
+
+	return failureMessage
+}

--- a/test/converters/xcresult3/model3/conversion.go
+++ b/test/converters/xcresult3/model3/conversion.go
@@ -35,9 +35,16 @@ func Convert(data *TestData) (*TestSummary, error) {
 						return nil, fmt.Errorf("test case expected but got: %s", testCaseNode.Type)
 					}
 
+					className := strings.Split(testCaseNode.Identifier, "/")[0]
+					if className == "" {
+						// In rare cases the identifier is an empty string so we need to use the test suite name which is the
+						// same as the first part of the identifier in normal cases.
+						className = testSuiteNode.Name
+					}
+
 					testCase := TestCase{
 						Name:      testCaseNode.Name,
-						ClassName: strings.Split(testCaseNode.Identifier, "/")[0],
+						ClassName: className,
 						Time:      extractDuration(testCaseNode.Duration),
 						Result:    testCaseNode.Result,
 						Message:   extractFailureMessage(testCaseNode),

--- a/test/converters/xcresult3/model3/data.go
+++ b/test/converters/xcresult3/model3/data.go
@@ -1,0 +1,30 @@
+package model3
+
+import "time"
+
+type TestSummary struct {
+	TestPlans []TestPlan
+}
+
+type TestPlan struct {
+	Name        string
+	TestBundles []TestBundle
+}
+
+type TestBundle struct {
+	Name       string
+	TestSuites []TestSuite
+}
+
+type TestSuite struct {
+	Name      string
+	TestCases []TestCase
+}
+
+type TestCase struct {
+	Name      string
+	ClassName string
+	Time      time.Duration
+	Result    TestResult
+	Message   string
+}

--- a/test/converters/xcresult3/model3/export.go
+++ b/test/converters/xcresult3/model3/export.go
@@ -1,0 +1,35 @@
+package model3
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type TestAttachmentDetails struct {
+	TestIdentifier string       `json:"testIdentifier"`
+	Attachments    []Attachment `json:"attachments"`
+}
+
+type Timestamp time.Time
+
+type Attachment struct {
+	ExportedFileName           string    `json:"exportedFileName"`
+	SuggestedHumanReadableName string    `json:"suggestedHumanReadableName"`
+	IsAssociatedWithFailure    bool      `json:"isAssociatedWithFailure"`
+	Timestamp                  Timestamp `json:"timestamp"`
+	ConfigurationName          string    `json:"configurationName"`
+	DeviceName                 string    `json:"deviceName"`
+	DeviceID                   string    `json:"deviceId"`
+	RepetitionNumber           int       `json:"repetitionNumber"`
+}
+
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
+	var timestamp float64
+	if err := json.Unmarshal(b, &timestamp); err != nil {
+		return err
+	}
+
+	*t = Timestamp(time.Unix(int64(timestamp), 0))
+
+	return nil
+}

--- a/test/converters/xcresult3/model3/testresults.go
+++ b/test/converters/xcresult3/model3/testresults.go
@@ -1,0 +1,63 @@
+package model3
+
+type TestNodeType string
+
+// These are all the types the xcresulttool (version 23500, format version 3.53) supports.
+const (
+	TestNodeTypeTestPlan       TestNodeType = "Test Plan"
+	TestNodeTypeUnitTestBundle TestNodeType = "Unit test bundle"
+	TestNodeTypeUITestBundle   TestNodeType = "UI test bundle"
+	TestNodeTypeTestSuite      TestNodeType = "Test Suite"
+	TestNodeTypeTestCase       TestNodeType = "Test Case"
+	TestNodeTypeDevice         TestNodeType = "Device"
+	TestNodeTypeTestPlanConfig TestNodeType = "Test Plan Configuration"
+	TestNodeTypeArguments      TestNodeType = "Arguments"
+	TestNodeTypeRepetition     TestNodeType = "Repetition"
+	TestNodeTypeTestCaseRun    TestNodeType = "Test Case Run"
+	TestNodeTypeFailureMessage TestNodeType = "Failure Message"
+	TestNodeTypeSourceCodeRef  TestNodeType = "Source Code Reference"
+	TestNodeTypeAttachment     TestNodeType = "Attachment"
+	TestNodeTypeExpression     TestNodeType = "Expression"
+	TestNodeTypeTestValue      TestNodeType = "Test Value"
+)
+
+type TestResult string
+
+const (
+	TestResultPassed          TestResult = "Passed"
+	TestResultFailed          TestResult = "Failed"
+	TestResultSkipped         TestResult = "Skipped"
+	TestResultExpectedFailure TestResult = "Expected Failure"
+	TestResultUnknown         TestResult = "unknown"
+)
+
+type TestData struct {
+	Devices                []Devices       `json:"devices"`
+	TestNodes              []TestNode      `json:"testNodes"`
+	TestPlanConfigurations []Configuration `json:"testPlanConfigurations"`
+}
+
+type Devices struct {
+	Identifier   string `json:"deviceId"`
+	Name         string `json:"deviceName"`
+	Architecture string `json:"architecture"`
+	ModelName    string `json:"modelName"`
+	Platform     string `json:"platform"`
+	OS           string `json:"osVersion"`
+}
+
+type TestNode struct {
+	Identifier string       `json:"nodeIdentifier"`
+	Type       TestNodeType `json:"nodeType"`
+	Name       string       `json:"name"`
+	Details    string       `json:"details"`
+	Duration   string       `json:"duration"`
+	Result     TestResult   `json:"result"`
+	Tags       []string     `json:"tags"`
+	Children   []TestNode   `json:"children"`
+}
+
+type Configuration struct {
+	Identifier string `json:"configurationId"`
+	Name       string `json:"configurationName"`
+}

--- a/test/converters/xcresult3/xcresult3.go
+++ b/test/converters/xcresult3/xcresult3.go
@@ -1,5 +1,7 @@
 package xcresult3
 
+import "github.com/bitrise-steplib/steps-deploy-to-bitrise-io/test/converters/xcresult3/model3"
+
 // Parse parses the given xcresult file's ActionsInvocationRecord and the list of ActionTestPlanRunSummaries.
 func Parse(pth string) (*ActionsInvocationRecord, []ActionTestPlanRunSummaries, error) {
 	var r ActionsInvocationRecord
@@ -17,4 +19,13 @@ func Parse(pth string) (*ActionsInvocationRecord, []ActionTestPlanRunSummaries, 
 		summaries = append(summaries, s)
 	}
 	return &r, summaries, nil
+}
+
+func ParseTestResults(pth string) (*model3.TestData, error) {
+	var data model3.TestData
+	if err := xcresulttoolGet(pth, "", &data); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
 }

--- a/test/converters/xcresult3/xcresult3.go
+++ b/test/converters/xcresult3/xcresult3.go
@@ -3,9 +3,9 @@ package xcresult3
 import "github.com/bitrise-steplib/steps-deploy-to-bitrise-io/test/converters/xcresult3/model3"
 
 // Parse parses the given xcresult file's ActionsInvocationRecord and the list of ActionTestPlanRunSummaries.
-func Parse(pth string) (*ActionsInvocationRecord, []ActionTestPlanRunSummaries, error) {
+func Parse(pth string, useLegacyFlag bool) (*ActionsInvocationRecord, []ActionTestPlanRunSummaries, error) {
 	var r ActionsInvocationRecord
-	if err := xcresulttoolGet(pth, "", &r); err != nil {
+	if err := xcresulttoolGet(pth, "", useLegacyFlag, &r); err != nil {
 		return nil, nil, err
 	}
 
@@ -13,7 +13,7 @@ func Parse(pth string) (*ActionsInvocationRecord, []ActionTestPlanRunSummaries, 
 	for _, action := range r.Actions.Values {
 		refID := action.ActionResult.TestsRef.ID.Value
 		var s ActionTestPlanRunSummaries
-		if err := xcresulttoolGet(pth, refID, &s); err != nil {
+		if err := xcresulttoolGet(pth, refID, useLegacyFlag, &s); err != nil {
 			return nil, nil, err
 		}
 		summaries = append(summaries, s)
@@ -23,7 +23,7 @@ func Parse(pth string) (*ActionsInvocationRecord, []ActionTestPlanRunSummaries, 
 
 func ParseTestResults(pth string) (*model3.TestData, error) {
 	var data model3.TestData
-	if err := xcresulttoolGet(pth, "", &data); err != nil {
+	if err := xcresulttoolGet(pth, "", false, &data); err != nil {
 		return nil, err
 	}
 

--- a/test/converters/xcresult3/xcresulttool.go
+++ b/test/converters/xcresult3/xcresulttool.go
@@ -71,7 +71,7 @@ func xcresulttoolGet(xcresultPth, id string, useLegacyFlag bool, v interface{}) 
 		return err
 	}
 
-	if supportsNewMethod {
+	if supportsNewMethod && !useLegacyFlag {
 		args = append(args, "test-results", "tests")
 	} else {
 		args = append(args, "--format", "json")
@@ -110,7 +110,7 @@ func xcresulttoolExport(xcresultPth, id, outputPth string, useLegacyFlag bool) e
 		return err
 	}
 
-	if supportsNewMethod {
+	if supportsNewMethod && !useLegacyFlag {
 		args = append(args, "attachments")
 	} else {
 		args = append(args, "--type", "file")

--- a/test/converters/xcresult3/xcresulttool.go
+++ b/test/converters/xcresult3/xcresulttool.go
@@ -18,7 +18,7 @@ func isXcresulttoolAvailable() bool {
 	return command.New("xcrun", "--find", "xcresulttool").Run() == nil
 }
 
-func isLegacyFlagNeededForXcresulttoolVersion() (bool, error) {
+func supportsNewExtractionMethods() (bool, error) {
 	args := []string{"xcresulttool", "version"}
 	cmd := command.New("xcrun", args...)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
@@ -42,21 +42,31 @@ func isLegacyFlagNeededForXcresulttoolVersion() (bool, error) {
 	}
 
 	return version >= 23_021, nil // Xcode 16 beta3 has version 23021
+
+	//fmt.Println("xcresulttool version:", version)
+	//
+	//return false, nil
 }
 
 // xcresulttoolGet performs xcrun xcresulttool get with --id flag defined if id provided and marshals the output into v.
 func xcresulttoolGet(xcresultPth, id string, v interface{}) error {
-	args := []string{"xcresulttool", "get", "--format", "json", "--path", xcresultPth}
-	if id != "" {
-		args = append(args, "--id", id)
-	}
+	args := []string{"xcresulttool", "get"}
 
-	isLegacyFlag, err := isLegacyFlagNeededForXcresulttoolVersion()
+	supportsNewMethod, err := supportsNewExtractionMethods()
 	if err != nil {
 		return err
 	}
-	if isLegacyFlag {
-		args = append(args, "--legacy")
+
+	if supportsNewMethod {
+		args = append(args, "test-results", "tests")
+	} else {
+		args = append(args, "--format", "json")
+	}
+
+	args = append(args, "--path", xcresultPth)
+
+	if id != "" {
+		args = append(args, "--id", id)
 	}
 
 	cmd := command.New("xcrun", args...)
@@ -75,13 +85,24 @@ func xcresulttoolGet(xcresultPth, id string, v interface{}) error {
 
 // xcresulttoolExport exports a file with the given id at the given output path.
 func xcresulttoolExport(xcresultPth, id, outputPth string) error {
-	args := []string{"xcresulttool", "export", "--path", xcresultPth, "--id", id, "--output-path", outputPth, "--type", "file"}
-	isLegacyFlag, err := isLegacyFlagNeededForXcresulttoolVersion()
+	args := []string{"xcresulttool", "export"}
+
+	supportsNewMethod, err := supportsNewExtractionMethods()
 	if err != nil {
 		return err
 	}
-	if isLegacyFlag {
-		args = append(args, "--legacy")
+
+	if supportsNewMethod {
+		args = append(args, "attachments")
+	} else {
+		args = append(args, "--type", "file")
+	}
+
+	args = append(args, "--path", xcresultPth)
+	args = append(args, "--output-path", outputPth)
+
+	if id != "" {
+		args = append(args, "--id", id)
 	}
 
 	cmd := command.New("xcrun", args...)

--- a/test/converters/xcresult3/xcresulttool.go
+++ b/test/converters/xcresult3/xcresulttool.go
@@ -42,10 +42,6 @@ func supportsNewExtractionMethods() (bool, error) {
 	}
 
 	return version >= 23_021, nil // Xcode 16 beta3 has version 23021
-
-	//fmt.Println("xcresulttool version:", version)
-	//
-	//return false, nil
 }
 
 // xcresulttoolGet performs xcrun xcresulttool get with --id flag defined if id provided and marshals the output into v.

--- a/test/testdata/ios_device_config_xml_output.golden
+++ b/test/testdata/ios_device_config_xml_output.golden
@@ -1,50 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
- <testsuite name="DarkAndLightModeTests" tests="3" failures="1" skipped="0" errors="0" time="0.3750969171524048">
-  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.11242496967315674">
-   <failure>/Users/vagrant/git/DarkAndLightModeTests/DarkAndLightModeTests.swift:25 - failed - Reached 1</failure>
-  </testcase>
-  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.0011119842529296875"></testcase>
-  <testcase configuration-hash="" name="testPerformanceExample()" classname="DarkAndLightModeTests" time="0.26155996322631836"></testcase>
+ <testsuite name="DarkAndLightModeTests" tests="2" failures="0" skipped="0" errors="0" time="0.317">
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.057"></testcase>
+  <testcase configuration-hash="" name="testPerformanceExample()" classname="DarkAndLightModeTests" time="0.26"></testcase>
  </testsuite>
- <testsuite name="DarkAndLightModeUITests" tests="14" failures="12" skipped="0" errors="0" time="92.95631325244904">
-  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeUITests" time="3.8267470598220825"></testcase>
-  <testcase configuration-hash="" name="testLaunchPerformance()" classname="DarkAndLightModeUITests" time="28.429319024086"></testcase>
-  <testcase configuration-hash="16789993f7012553276a039f8829bcbf" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="7.017634034156799">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="16789993f7012553276a039f8829bcbf" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.156491994857788">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="16789993f7012553276a039f8829bcbf" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.570378065109253">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="bb9ffdfb3f0e2ac59b09a83bd8c1ba55" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="7.531908988952637">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="bb9ffdfb3f0e2ac59b09a83bd8c1ba55" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.387096047401428">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="bb9ffdfb3f0e2ac59b09a83bd8c1ba55" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.1682270765304565">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="990bacacade8f7dc5b2d9f4d042c3349" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="7.013818025588989">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="990bacacade8f7dc5b2d9f4d042c3349" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.297332048416138">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="990bacacade8f7dc5b2d9f4d042c3349" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.593717932701111">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="09150042f5350c48cdf9784faaa4b911" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.915426015853882">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="09150042f5350c48cdf9784faaa4b911" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="4.210652947425842">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
-  </testcase>
-  <testcase configuration-hash="09150042f5350c48cdf9784faaa4b911" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="3.837563991546631">
-   <failure>/Users/vagrant/git/DarkAndLightModeUITests/DarkAndLightModeUITestsLaunchTests.swift:32 - XCTAssertTrue failed</failure>
+ <testsuite name="DarkAndLightModeUITests" tests="3" failures="1" skipped="0" errors="0" time="36">
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeUITests" time="3"></testcase>
+  <testcase configuration-hash="" name="testLaunchPerformance()" classname="DarkAndLightModeUITests" time="28"></testcase>
+  <testcase configuration-hash="" name="testLaunch()" classname="DarkAndLightModeUITestsLaunchTests" time="5">
+   <failure></failure>
   </testcase>
  </testsuite>
 </testsuites>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Since Xcode 16 we have a new way to extract test information from the xcresult file with xcresulttool. This PR removes the legacy flag and updates the step to use the new method. 

### Investigation details

The new method uses a completely different data structure and cannot be easily fit into the old one. So there are a new set data models and the whole method is separated from the old one.
