### PR TITLE
[CI-4808] Legacy xcresult parsing input

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,29 +52,30 @@ var fileBaseNamesToSkip = []string{".DS_Store"}
 
 // Config ...
 type Config struct {
-	PipelineIntermediateFiles     string `env:"pipeline_intermediate_files"`
-	BuildURL                      string `env:"build_url,required"`
-	APIToken                      string `env:"build_api_token,required"`
-	IsCompress                    bool   `env:"is_compress,opt[true,false]"`
-	ZipName                       string `env:"zip_name"`
-	DeployPath                    string `env:"deploy_path"`
-	NotifyUserGroups              string `env:"notify_user_groups"`
-	AlwaysNotifyUserGroups        string `env:"always_notify_user_groups"`
-	NotifyEmailList               string `env:"notify_email_list"`
-	IsPublicPageEnabled           bool   `env:"is_enable_public_page,opt[true,false]"`
-	PublicInstallPageMapFormat    string `env:"public_install_page_url_map_format,required"`
-	PermanentDownloadURLMapFormat string `env:"permanent_download_url_map_format,required"`
-	DetailsPageURLMapFormat       string `env:"details_page_url_map_format,required"`
-	BuildSlug                     string `env:"BITRISE_BUILD_SLUG,required"`
-	TestDeployDir                 string `env:"BITRISE_TEST_DEPLOY_DIR,required"`
-	AppSlug                       string `env:"BITRISE_APP_SLUG,required"`
-	AddonAPIBaseURL               string `env:"addon_api_base_url,required"`
-	AddonAPIToken                 string `env:"addon_api_token"`
-	FilesToRedact                 string `env:"files_to_redact"`
-	DebugMode                     bool   `env:"debug_mode,opt[true,false]"`
-	BundletoolVersion             string `env:"bundletool_version,required"`
-	UploadConcurrency             string `env:"BITRISE_DEPLOY_UPLOAD_CONCURRENCY"`
-	HTMLReportDir                 string `env:"BITRISE_HTML_REPORT_DIR"`
+	PipelineIntermediateFiles         string `env:"pipeline_intermediate_files"`
+	BuildURL                          string `env:"build_url,required"`
+	APIToken                          string `env:"build_api_token,required"`
+	IsCompress                        bool   `env:"is_compress,opt[true,false]"`
+	ZipName                           string `env:"zip_name"`
+	DeployPath                        string `env:"deploy_path"`
+	NotifyUserGroups                  string `env:"notify_user_groups"`
+	AlwaysNotifyUserGroups            string `env:"always_notify_user_groups"`
+	NotifyEmailList                   string `env:"notify_email_list"`
+	IsPublicPageEnabled               bool   `env:"is_enable_public_page,opt[true,false]"`
+	PublicInstallPageMapFormat        string `env:"public_install_page_url_map_format,required"`
+	PermanentDownloadURLMapFormat     string `env:"permanent_download_url_map_format,required"`
+	DetailsPageURLMapFormat           string `env:"details_page_url_map_format,required"`
+	BuildSlug                         string `env:"BITRISE_BUILD_SLUG,required"`
+	TestDeployDir                     string `env:"BITRISE_TEST_DEPLOY_DIR,required"`
+	AppSlug                           string `env:"BITRISE_APP_SLUG,required"`
+	AddonAPIBaseURL                   string `env:"addon_api_base_url,required"`
+	AddonAPIToken                     string `env:"addon_api_token"`
+	FilesToRedact                     string `env:"files_to_redact"`
+	DebugMode                         bool   `env:"debug_mode,opt[true,false]"`
+	UseLegacyXCResultExtractionMethod bool   `env:"use_legacy_xcresult_extraction_method,opt[true,false]"`
+	BundletoolVersion                 string `env:"bundletool_version,required"`
+	UploadConcurrency                 string `env:"BITRISE_DEPLOY_UPLOAD_CONCURRENCY"`
+	HTMLReportDir                     string `env:"BITRISE_HTML_REPORT_DIR"`
 }
 
 // PublicInstallPage ...
@@ -449,7 +450,7 @@ func stepNameWithIndex(stepInfo models.TestResultStepInfo) string {
 func deployTestResults(config Config, logger loggerV2.Logger) {
 	logger.Println()
 	logger.Infof("Collecting test results...")
-	testResults, err := test.ParseTestResults(config.TestDeployDir, logger)
+	testResults, err := test.ParseTestResults(config.TestDeployDir, config.UseLegacyXCResultExtractionMethod, logger)
 	if err != nil {
 		logger.Warnf("Failed to parse test results: %s", err)
 		return

--- a/step.yml
+++ b/step.yml
@@ -336,6 +336,21 @@ inputs:
     value_options:
     - "false"
     - "true"
+- use_legacy_xcresult_extraction_method: "false"
+  opts:
+    category: Debugging
+    title: Legacy extraction method for Xcode test results
+    summary: |-
+      The Step will try to extract the test results with the older extraction method.
+    description: |-
+      The Step will try to extract the test results with the older extraction method.
+    
+      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results. 
+      If you encounter this issue, please set this input to `true` and try again.
+    is_required: true
+    value_options:
+    - "false"
+    - "true"
 outputs:
 - BITRISE_PUBLIC_INSTALL_PAGE_URL:
   opts:

--- a/step.yml
+++ b/step.yml
@@ -344,8 +344,8 @@ inputs:
       The Step will try to extract the test results with the older extraction method.
     description: |-
       The Step will try to extract the test results with the older extraction method.
-    
-      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results. 
+
+      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results.
       If you encounter this issue, please set this input to `true` and try again.
     is_required: true
     value_options:

--- a/step.yml
+++ b/step.yml
@@ -341,12 +341,14 @@ inputs:
     category: Debugging
     title: Legacy extraction method for Xcode test results
     summary: |-
-      The Step will try to extract the test results with the older extraction method.
+      The Step will try to extract the test results with the Xcode 15 extraction method.
     description: |-
-      The Step will try to extract the test results with the older extraction method.
+      The Step will try to extract the test results with the Xcode 15 extraction method.
 
-      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results.
+      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results. 
       If you encounter this issue, please set this input to `true` and try again.
+      
+      What does this input does is that it calls the `xcresulttool` command with the `--legacy` flag.
     is_required: true
     value_options:
     - "false"

--- a/step.yml
+++ b/step.yml
@@ -345,9 +345,9 @@ inputs:
     description: |-
       The Step will try to extract the test results with the Xcode 15 extraction method.
 
-      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results. 
+      Some Xcode test results are not compatible with the new extraction method and cannot extract the test results.
       If you encounter this issue, please set this input to `true` and try again.
-      
+
       What does this input does is that it calls the `xcresulttool` command with the `--legacy` flag.
     is_required: true
     value_options:

--- a/test/converters/converters.go
+++ b/test/converters/converters.go
@@ -12,10 +12,11 @@ import (
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/test/junit"
 )
 
-// Intf is the required interface a converter need to match
+// Intf is the required interface a converter needs to match
 type Intf interface {
 	XML() (junit.XML, error)
 	Detect([]string) bool
+	Setup(useOldXCResultExtractionMethod bool)
 }
 
 var converters = []Intf{

--- a/test/converters/junitxml/junitxml.go
+++ b/test/converters/junitxml/junitxml.go
@@ -34,6 +34,8 @@ type Converter struct {
 	results []resultReader
 }
 
+func (c *Converter) Setup(_ bool) {}
+
 // Detect return true if the test results a Juni4 XML file
 func (h *Converter) Detect(files []string) bool {
 	h.results = nil

--- a/test/converters/junitxml/junitxml.go
+++ b/test/converters/junitxml/junitxml.go
@@ -37,15 +37,15 @@ type Converter struct {
 func (c *Converter) Setup(_ bool) {}
 
 // Detect return true if the test results a Juni4 XML file
-func (h *Converter) Detect(files []string) bool {
-	h.results = nil
+func (c *Converter) Detect(files []string) bool {
+	c.results = nil
 	for _, file := range files {
 		if strings.HasSuffix(file, ".xml") || strings.HasSuffix(file, ".junit") {
-			h.results = append(h.results, &fileReader{Filename: file})
+			c.results = append(c.results, &fileReader{Filename: file})
 		}
 	}
 
-	return len(h.results) > 0
+	return len(c.results) > 0
 }
 
 // merges Suites->Cases->Error and Suites->Cases->SystemErr field values into Suites->Cases->Failure field
@@ -119,10 +119,10 @@ func parseTestSuites(result resultReader) ([]junit.TestSuite, error) {
 }
 
 // XML returns the xml content bytes
-func (h *Converter) XML() (junit.XML, error) {
+func (c *Converter) XML() (junit.XML, error) {
 	var xmlContent junit.XML
 
-	for _, result := range h.results {
+	for _, result := range c.results {
 		testSuites, err := parseTestSuites(result)
 		if err != nil {
 			return junit.XML{}, err

--- a/test/converters/xcresult/xcresult.go
+++ b/test/converters/xcresult/xcresult.go
@@ -17,6 +17,8 @@ type Converter struct {
 	testSummariesPlistPath string
 }
 
+func (c *Converter) Setup(_ bool) {}
+
 // Detect ...
 func (h *Converter) Detect(files []string) bool {
 	h.files = files

--- a/test/converters/xcresult/xcresult.go
+++ b/test/converters/xcresult/xcresult.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"unicode"
 
+	"howett.net/plist"
+
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/test/junit"
-	"howett.net/plist"
 )
 
 // Converter ...
@@ -20,16 +21,16 @@ type Converter struct {
 func (c *Converter) Setup(_ bool) {}
 
 // Detect ...
-func (h *Converter) Detect(files []string) bool {
-	h.files = files
-	for _, file := range h.files {
+func (c *Converter) Detect(files []string) bool {
+	c.files = files
+	for _, file := range c.files {
 		if filepath.Ext(file) == ".xcresult" {
 			testSummariesPlistPath := filepath.Join(file, "TestSummaries.plist")
 			if exist, err := pathutil.IsPathExists(testSummariesPlistPath); err != nil || !exist {
 				continue
 			}
 
-			h.testSummariesPlistPath = testSummariesPlistPath
+			c.testSummariesPlistPath = testSummariesPlistPath
 			return true
 		}
 	}
@@ -64,8 +65,8 @@ func filterIllegalChars(data []byte) (filtered []byte) {
 }
 
 // XML ...
-func (h *Converter) XML() (junit.XML, error) {
-	data, err := fileutil.ReadBytesFromFile(h.testSummariesPlistPath)
+func (c *Converter) XML() (junit.XML, error) {
+	data, err := fileutil.ReadBytesFromFile(c.testSummariesPlistPath)
 	if err != nil {
 		return junit.XML{}, err
 	}

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -24,7 +24,8 @@ import (
 
 // Converter ...
 type Converter struct {
-	xcresultPth string
+	xcresultPth               string
+	useLegacyExtractionMethod bool
 }
 
 func majorVersion(document serialized.Object) (int, error) {
@@ -52,6 +53,10 @@ func documentMajorVersion(pth string) (int, error) {
 	}
 
 	return majorVersion(info)
+}
+
+func (c *Converter) Setup(useOldXCResultExtractionMethod bool) {
+	c.useLegacyExtractionMethod = useOldXCResultExtractionMethod
 }
 
 // Detect ...
@@ -99,9 +104,9 @@ func (c *Converter) XML() (junit.XML, error) {
 		return junit.XML{}, err
 	}
 
-	useLegacyFlag := false
+	useLegacyFlag := c.useLegacyExtractionMethod
 
-	if supportsNewMethod {
+	if supportsNewMethod && !useLegacyFlag {
 		log.Infof("Using new extraction method")
 
 		junitXml, err := parse(c.xcresultPth)

--- a/test/test.go
+++ b/test/test.go
@@ -129,7 +129,7 @@ The Test Deploy directory has the following directory structure:
 	        ├── screenshot_3.png
 	        └── test-info.json
 */
-func ParseTestResults(testsRootDir string, logger logV2.Logger) (results Results, err error) {
+func ParseTestResults(testsRootDir string, useLegacyXCResultExtractionMethod bool, logger logV2.Logger) (results Results, err error) {
 	// read dirs in base tests dir
 	// <root_tests_dir>
 

--- a/test/test.go
+++ b/test/test.go
@@ -194,7 +194,9 @@ func ParseTestResults(testsRootDir string, useLegacyXCResultExtractionMethod boo
 			for _, converter := range converters.List() {
 				logger.Debugf("Running converter: %T", converter)
 
-				// skip if couldn't find converter for content type
+				converter.Setup(useLegacyXCResultExtractionMethod)
+
+				// skip if it couldn't find a converter for the content type
 				detected := converter.Detect(testFiles)
 
 				logger.Debugf("known test result detected: %v", detected)

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -185,7 +185,7 @@ func Test_ParseXctestResults(t *testing.T) {
 			t.Fatal("failed to create temp dir, error:", err)
 		}
 
-		bundle, err := ParseTestResults(testsDir, logV2.NewLogger())
+		bundle, err := ParseTestResults(testsDir, false, logV2.NewLogger())
 		if err != nil {
 			t.Fatal("failed to get bundle, error:", err)
 		}
@@ -225,7 +225,7 @@ func Test_ParseXctestResults(t *testing.T) {
 			t.Fatal("failed to create dummy files in dir, error:", err)
 		}
 
-		bundle, err := ParseTestResults(testsDir, logV2.NewLogger())
+		bundle, err := ParseTestResults(testsDir, false, logV2.NewLogger())
 		if err != nil {
 			t.Fatal("failed to get bundle, error:", err)
 		}
@@ -263,7 +263,7 @@ func Test_ParseXctestResults(t *testing.T) {
 			t.Fatal("failed to create dummy files in dir, error:", err)
 		}
 
-		bundle, err := ParseTestResults(testsDir, logV2.NewLogger())
+		bundle, err := ParseTestResults(testsDir, false, logV2.NewLogger())
 		if err != nil {
 			t.Fatal("failed to get bundle, error:", err)
 		}
@@ -308,7 +308,7 @@ func Test_ParseXctest3Results(t *testing.T) {
 	err = copyCmd.Run()
 	require.NoError(t, err)
 
-	bundle, err := ParseTestResults(testDir, logV2.NewLogger())
+	bundle, err := ParseTestResults(testDir, false, logV2.NewLogger())
 	require.NoError(t, err)
 
 	want, err := fileutil.ReadStringFromFile(filepath.Join("testdata", "ios_device_config_xml_output.golden"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Some customers xcresult file might not be compatible with the new parsing (or there is a bug in the extraction tool) and this new input can force the step to use the legacy extraction method.