### PR TITLE
Xcresult retry test cases

### DIFF
--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -201,7 +201,7 @@ func parse(path string) (testreport.TestReport, error) {
 func parseTestBundle(testBundle model3.TestBundle) testreport.TestSuite {
 	failedCount := 0
 	skippedCount := 0
-	var totalDuration float64
+	var totalDuration time.Duration
 	var tests []testreport.TestCase
 
 	for _, testSuite := range testBundle.TestSuites {
@@ -215,7 +215,7 @@ func parseTestBundle(testBundle model3.TestBundle) testreport.TestSuite {
 					} else if test.Skipped != nil {
 						skippedCount++
 					}
-					totalDuration += test.Time
+					totalDuration += retry.Time
 
 					tests = append(tests, test)
 				}
@@ -227,7 +227,7 @@ func parseTestBundle(testBundle model3.TestBundle) testreport.TestSuite {
 				} else if test.Skipped != nil {
 					skippedCount++
 				}
-				totalDuration += test.Time
+				totalDuration += testCase.Time
 
 				tests = append(tests, test)
 			}
@@ -239,7 +239,7 @@ func parseTestBundle(testBundle model3.TestBundle) testreport.TestSuite {
 		Tests:     len(tests),
 		Failures:  failedCount,
 		Skipped:   skippedCount,
-		Time:      totalDuration,
+		Time:      totalDuration.Seconds(),
 		TestCases: tests,
 	}
 }

--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -206,28 +206,22 @@ func parseTestBundle(testBundle model3.TestBundle) testreport.TestSuite {
 
 	for _, testSuite := range testBundle.TestSuites {
 		for _, testCase := range testSuite.TestCases {
+			var testCasesToConvert []model3.TestCase
 			if len(testCase.Retries) > 0 {
-				for _, retry := range testCase.Retries {
-					test := parseTestCase(retry)
-
-					if test.Failure != nil {
-						failedCount++
-					} else if test.Skipped != nil {
-						skippedCount++
-					}
-					totalDuration += retry.Time
-
-					tests = append(tests, test)
-				}
+				testCasesToConvert = testCase.Retries
 			} else {
-				test := parseTestCase(testCase.TestCase)
+				testCasesToConvert = []model3.TestCase{testCase.TestCase}
+			}
+
+			for _, testCaseToConvert := range testCasesToConvert {
+				test := parseTestCase(testCaseToConvert)
 
 				if test.Failure != nil {
 					failedCount++
 				} else if test.Skipped != nil {
 					skippedCount++
 				}
-				totalDuration += testCase.Time
+				totalDuration += testCaseToConvert.Time
 
 				tests = append(tests, test)
 			}

--- a/test/converters/xcresult3/converter_test.go
+++ b/test/converters/xcresult3/converter_test.go
@@ -94,10 +94,16 @@ func TestConverter_XML(t *testing.T) {
 				},
 			},
 			{
-				Name: "BullsEyeFlakyTests", Tests: 2, Failures: 0, Skipped: 1, Time: 0.12,
+				Name: "BullsEyeFlakyTests", Tests: 3, Failures: 1, Skipped: 1, Time: 0.226,
 				TestCases: []testreport.TestCase{
 					{
-						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.1,
+						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.2,
+						Failure: &testreport.Failure{
+							Value: `BullsEyeFlakyTests.swift:43: XCTAssertEqual failed: ("1") is not equal to ("0") - Number is not even`,
+						},
+					},
+					{
+						Name: "testFlakyFeature()", ClassName: "BullsEyeFlakyTests", Time: 0.006,
 					},
 					{
 						Name: "testFlakySkip()", ClassName: "BullsEyeSkippedTests", Time: 0.02,

--- a/test/converters/xcresult3/model3/conversion.go
+++ b/test/converters/xcresult3/model3/conversion.go
@@ -83,7 +83,7 @@ func extractTestCases(nodes []TestNode, fallbackName string) ([]TestCaseWithRetr
 			return nil, warnings, fmt.Errorf("test case expected but got: %s", testCaseNode.Type)
 		}
 
-		testCase, testCaseWarnings := extractTestCase(testCaseNode, "", fallbackName)
+		testCase, testCaseWarnings := extractTestCase(testCaseNode, "", "", fallbackName)
 		warnings = append(warnings, testCaseWarnings...)
 
 		retries, retryWarnings, err := extractRetries(testCaseNode, fallbackName)
@@ -150,7 +150,7 @@ func extractRetries(testNode TestNode, fallbackName string) ([]TestCase, []strin
 	for _, child := range testNode.Children {
 		if child.Type == TestNodeTypeRepetition {
 			// Use the parent test node's identifier, instead of the repetition's identifier (1, 2, ...).
-			retry, testCaseWarnings := extractTestCase(child, testNode.Identifier, fallbackName)
+			retry, testCaseWarnings := extractTestCase(child, testNode.Identifier, testNode.Name, fallbackName)
 			warnings = append(warnings, testCaseWarnings...)
 			retries = append(retries, retry)
 		}
@@ -159,12 +159,17 @@ func extractRetries(testNode TestNode, fallbackName string) ([]TestCase, []strin
 	return retries, warnings, nil
 }
 
-func extractTestCase(testNode TestNode, customNodeIdentifier, fallbackClassName string) (TestCase, []string) {
+func extractTestCase(testNode TestNode, customNodeIdentifier, customName, fallbackClassName string) (TestCase, []string) {
 	var warnings []string
 
 	nodeIdentifier := testNode.Identifier
 	if customNodeIdentifier != "" {
 		nodeIdentifier = customNodeIdentifier
+	}
+
+	name := testNode.Name
+	if customName != "" {
+		name = customName
 	}
 
 	className := strings.Split(nodeIdentifier, "/")[0]
@@ -180,7 +185,7 @@ func extractTestCase(testNode TestNode, customNodeIdentifier, fallbackClassName 
 	}
 
 	return TestCase{
-		Name:      testNode.Name,
+		Name:      name,
 		ClassName: className,
 		Time:      extractDuration(testNode.Duration),
 		Result:    testNode.Result,

--- a/test/converters/xcresult3/model3/conversion.go
+++ b/test/converters/xcresult3/model3/conversion.go
@@ -166,13 +166,8 @@ func extractRetries(testNode TestNode, fallbackName string) ([]TestCase, []strin
 
 	for _, child := range testNode.Children {
 		if child.Type == TestNodeTypeRepetition {
-			// Use the original test node's identifier, instead of the repetition's identifier (1, 2, ...).
-			identifierSplit := strings.Split(testNode.Identifier, "/")
-			if len(identifierSplit) != 2 {
-				// If the identifier does not contain a class name, we use the fallback name.
-				return nil, nil, fmt.Errorf("expected identifier to contain a '/' but got: %s", testNode.Identifier)
-			}
-			className := identifierSplit[0]
+			// Use the parent test node's identifier, instead of the repetition's identifier (1, 2, ...).
+			className := strings.Split(testNode.Identifier, "/")[0]
 			if className == "" {
 				// In rare cases the identifier is an empty string, so we need to use the test suite name which is the
 				// same as the first part of the identifier in normal cases.

--- a/test/converters/xcresult3/model3/conversion_test.go
+++ b/test/converters/xcresult3/model3/conversion_test.go
@@ -95,35 +95,43 @@ func TestConversion(t *testing.T) {
 								TestSuites: []TestSuite{
 									{
 										Name: "TS1",
-										TestCases: []TestCase{
+										TestCases: []TestCaseWithRetries{
 											{
-												Name:      "TC1",
-												ClassName: "TS1",
-												Time:      500 * time.Millisecond,
-												Result:    "Passed",
+												TestCase: TestCase{
+													Name:      "TC1",
+													ClassName: "TS1",
+													Time:      500 * time.Millisecond,
+													Result:    "Passed",
+												},
 											},
 											{
-												Name:      "TC2",
-												ClassName: "TS1",
-												Time:      1 * time.Second,
-												Result:    "Failed",
+												TestCase: TestCase{
+													Name:      "TC2",
+													ClassName: "TS1",
+													Time:      1 * time.Second,
+													Result:    "Failed",
+												},
 											},
 										},
 									},
 									{
 										Name: "TS2",
-										TestCases: []TestCase{
+										TestCases: []TestCaseWithRetries{
 											{
-												Name:      "TC3",
-												ClassName: "TS2",
-												Time:      66 * time.Second,
-												Result:    "Skipped",
+												TestCase: TestCase{
+													Name:      "TC3",
+													ClassName: "TS2",
+													Time:      66 * time.Second,
+													Result:    "Skipped",
+												},
 											},
 											{
-												Name:      "TC4",
-												ClassName: "TS2",
-												Time:      30 * time.Millisecond,
-												Result:    "Passed",
+												TestCase: TestCase{
+													Name:      "TC4",
+													ClassName: "TS2",
+													Time:      30 * time.Millisecond,
+													Result:    "Passed",
+												},
 											},
 										},
 									},
@@ -134,12 +142,14 @@ func TestConversion(t *testing.T) {
 								TestSuites: []TestSuite{
 									{
 										Name: "TS3",
-										TestCases: []TestCase{
+										TestCases: []TestCaseWithRetries{
 											{
-												Name:      "TC5",
-												ClassName: "TS3",
-												Time:      15 * time.Second,
-												Result:    "Passed",
+												TestCase: TestCase{
+													Name:      "TC5",
+													ClassName: "TS3",
+													Time:      15 * time.Second,
+													Result:    "Passed",
+												},
 											},
 										},
 									},
@@ -184,12 +194,14 @@ func TestConversion(t *testing.T) {
 								TestSuites: []TestSuite{
 									{
 										Name: "TB1",
-										TestCases: []TestCase{
+										TestCases: []TestCaseWithRetries{
 											{
-												Name:      "TC1",
-												ClassName: "TB1",
-												Time:      500 * time.Millisecond,
-												Result:    "Passed",
+												TestCase: TestCase{
+													Name:      "TC1",
+													ClassName: "TB1",
+													Time:      500 * time.Millisecond,
+													Result:    "Passed",
+												},
 											},
 										},
 									},

--- a/test/converters/xcresult3/model3/data.go
+++ b/test/converters/xcresult3/model3/data.go
@@ -18,7 +18,12 @@ type TestBundle struct {
 
 type TestSuite struct {
 	Name      string
-	TestCases []TestCase
+	TestCases []TestCaseWithRetries
+}
+
+type TestCaseWithRetries struct {
+	TestCase
+	Retries []TestCase
 }
 
 type TestCase struct {

--- a/test/testdata/ios_device_config_xml_output.golden
+++ b/test/testdata/ios_device_config_xml_output.golden
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
- <testsuite name="DarkAndLightModeTests" tests="2" failures="0" skipped="0" time="0.317">
-  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.057"></testcase>
+ <testsuite name="DarkAndLightModeTests" tests="3" failures="1" skipped="0" time="0.3711">
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.11">
+   <failure>DarkAndLightModeTests.swift:25: failed - Reached 1</failure>
+  </testcase>
+  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.0011"></testcase>
   <testcase configuration-hash="" name="testPerformanceExample()" classname="DarkAndLightModeTests" time="0.26"></testcase>
  </testsuite>
  <testsuite name="DarkAndLightModeUITests" tests="3" failures="1" skipped="0" time="36">


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

Currently the test result converter isn't handling test case retries for Xcode test results. Only the summary test case is added to the internal test report model, actual test case reruns are not parsed.

This PR updates the Xcode test result parser to parse test case retries and add the reties as separate test cases to the converted test report, the summary test case is not part of the converted report anymore.

This xcresult:

```
"children" : [
  {
    "children" : [
      {
        "name" : "DarkAndLightModeTests.swift:25: failed - Reached 1",
        "nodeType" : "Failure Message",
        "result" : "Failed"
      }
    ],
    "duration" : "0,11s",
    "durationInSeconds" : 0.11242496967315674,
    "name" : "Retry 1",
    "nodeIdentifier" : "1",
    "nodeType" : "Repetition",
    "result" : "Failed"
  },
  {
    "duration" : "0,0011s",
    "durationInSeconds" : 0.0011119842529296875,
    "name" : "Retry 2",
    "nodeIdentifier" : "2",
    "nodeType" : "Repetition",
    "result" : "Passed"
  }
],
"details" : "⚠️ Passed after 1 retry",
"duration" : "0,057s",
"durationInSeconds" : 0.05676847696304321,
"name" : "testExample()",
"nodeIdentifier" : "DarkAndLightModeTests/testExample()",
"nodeIdentifierURL" : "test://com.apple.xcode/DarkAndLightMode/DarkAndLightModeTests/DarkAndLightModeTests/testExample",
"nodeType" : "Test Case",
"result" : "Passed"
},
```

gets converted into this JUnit xml:

```
  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.11">
   <failure>DarkAndLightModeTests.swift:25: failed - Reached 1</failure>
  </testcase>
  <testcase configuration-hash="" name="testExample()" classname="DarkAndLightModeTests" time="0.057"></testcase>
```