### PR TITLE
[CI-5225] Keep xcresult attachments in chronological order

### DIFF
--- a/test/converters/xcresult3/converter.go
+++ b/test/converters/xcresult3/converter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -283,7 +284,14 @@ func extractAttachments(xcresultPath, outputPath string) (map[string][]string, e
 
 	var fileCounterMap = make(map[string]int)
 	for _, attachmentDetail := range manifest {
-		for _, attachment := range attachmentDetail.Attachments {
+		// Sort attachments by Timestamp ascending (oldest first)
+		attachments := attachmentDetail.Attachments
+
+		sort.Slice(attachments, func(i, j int) bool {
+			return time.Time(attachments[i].Timestamp).Before(time.Time(attachments[j].Timestamp))
+		})
+
+		for _, attachment := range attachments {
 			oldPath := filepath.Join(outputPath, attachment.ExportedFileName)
 			newPath := filepath.Join(outputPath, attachment.SuggestedHumanReadableName)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
