### PR TITLE
Migrate the log package to v2

### DIFF
--- a/deployment/collector.go
+++ b/deployment/collector.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 const (
@@ -72,6 +72,7 @@ type Collector struct {
 	zipDirFunction  ZipDirFunction
 	envRepository   env.Repository
 	temporaryFolder string
+	logger          log.Logger
 }
 
 // NewCollector ...
@@ -81,6 +82,7 @@ func NewCollector(
 	zipDirFunction ZipDirFunction,
 	envRepository env.Repository,
 	temporaryFolder string,
+	logger log.Logger,
 ) Collector {
 	return Collector{
 		zipComparator:   zipComparator,
@@ -88,6 +90,7 @@ func NewCollector(
 		zipDirFunction:  zipDirFunction,
 		envRepository:   envRepository,
 		temporaryFolder: temporaryFolder,
+		logger:          logger,
 	}
 }
 
@@ -258,12 +261,12 @@ func (c Collector) mergeZipPairs(deployableItems []DeployableItem) []DeployableI
 		for pth, zipBuildArtifact := range zipBuildArtifacts {
 			same, err := c.zipComparator.Equals(pipelineDir.Path, zipBuildArtifact.Path)
 			if err != nil {
-				log.Warnf("Couldn't compare Pipeline File (%s) and Build Artifact (%s): %s", pipelineDir.Path, zipBuildArtifact.Path, err)
+				c.logger.Warnf("Couldn't compare Pipeline File (%s) and Build Artifact (%s): %s", pipelineDir.Path, zipBuildArtifact.Path, err)
 				continue
 			}
 
 			if same {
-				log.Warnf("Same directory specified both as Build Artifact (%s) and Pipeline File (%s), keeping Pipeline File...", zipBuildArtifact.Path, pipelineDir.Path)
+				c.logger.Warnf("Same directory specified both as Build Artifact (%s) and Pipeline File (%s), keeping Pipeline File...", zipBuildArtifact.Path, pipelineDir.Path)
 				delete(zipBuildArtifacts, pth)
 			}
 		}

--- a/deployment/collector_test.go
+++ b/deployment/collector_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/mocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -140,8 +141,8 @@ func Test_GivenIntermediateFiles_WhenProcessing_ThenConvertsCorrectly(t *testing
 			for key, value := range tt.environment {
 				mockRepository.On("Get", key).Return(value).Once()
 			}
-			zipComparator := NewZipComparator(DefaultReadZipFunction)
-			collector := NewCollector(zipComparator, isDirFunction(directories), emptyZipFunction(), mockRepository, tempDir)
+			zipComparator := NewZipComparator(DefaultReadZipFunction, log.NewLogger())
+			collector := NewCollector(zipComparator, isDirFunction(directories), emptyZipFunction(), mockRepository, tempDir, log.NewLogger())
 
 			var deployableItems []DeployableItem
 			deployableItems, err := collector.AddIntermediateFiles(deployableItems, tt.list)
@@ -276,9 +277,9 @@ func Test_GivenDeployFiles_WhenIntermediateFilesSpecified_ThenMergesThem(t *test
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			zipComparator := NewZipComparator(DefaultReadZipFunction)
+			zipComparator := NewZipComparator(DefaultReadZipFunction, log.NewLogger())
 			mockRepository := new(mocks.Repository)
-			collector := NewCollector(zipComparator, isDirFunction(directories), emptyZipFunction(), mockRepository, tempDir)
+			collector := NewCollector(zipComparator, isDirFunction(directories), emptyZipFunction(), mockRepository, tempDir, log.NewLogger())
 			deployableItems := ConvertPaths(tt.deployFiles)
 			deployableItems, err := collector.AddIntermediateFiles(deployableItems, tt.intermediateFiles)
 
@@ -340,9 +341,9 @@ func Test_GivenDeployDirectories_WhenIntermediateDirectoriesSpecified_ThenMerges
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			zipComparator := NewZipComparator(readZipFunction(zips))
+			zipComparator := NewZipComparator(readZipFunction(zips), log.NewLogger())
 			mockRepository := new(mocks.Repository)
-			collector := NewCollector(zipComparator, isDirFunction(directories), emptyZipFunction(), mockRepository, tempDir)
+			collector := NewCollector(zipComparator, isDirFunction(directories), emptyZipFunction(), mockRepository, tempDir, log.NewLogger())
 			deployableItems := ConvertPaths(tt.deployFiles)
 			deployableItems, err := collector.AddIntermediateFiles(deployableItems, tt.intermediateFiles)
 

--- a/deployment/zipcompare.go
+++ b/deployment/zipcompare.go
@@ -5,18 +5,20 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 // ZipComparator ...
 type ZipComparator struct {
 	readZipFunction ReadZipFunction
+	logger          log.Logger
 }
 
 // NewZipComparator ...
-func NewZipComparator(readZipFunction ReadZipFunction) ZipComparator {
+func NewZipComparator(readZipFunction ReadZipFunction, logger log.Logger) ZipComparator {
 	return ZipComparator{
 		readZipFunction: readZipFunction,
+		logger:          logger,
 	}
 }
 
@@ -35,7 +37,7 @@ func (c ZipComparator) Equals(aZip, bZip string) (bool, error) {
 	result := c.compareZipDescriptors(aDescriptor, bDescriptor)
 	hasChanges := result.hasChanges()
 	if hasChanges {
-		log.Debugf("%s and %s are not the same:\n%s", aZip, bZip, result)
+		c.logger.Debugf("%s and %s are not the same:\n%s", aZip, bZip, result)
 	}
 	return !hasChanges, nil
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/errorutil"
 	"github.com/bitrise-io/go-utils/v2/exitcode"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
-	loggerV2 "github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-io/go-utils/v2/ziputil"
 	iosparser "github.com/bitrise-io/go-xcode/v2/metaparser"
@@ -101,13 +101,13 @@ type ArtifactURLCollection struct {
 
 const zippedXcarchiveExt = ".xcarchive.zip"
 
-func fail(logger loggerV2.Logger, format string, v ...interface{}) {
+func fail(logger log.Logger, format string, v ...interface{}) {
 	logger.Errorf(format, v...)
 	os.Exit(int(exitcode.Failure))
 }
 
 func main() {
-	logger := loggerV2.NewLogger() // TODO: replace v1 logger with v2 logger all around the code
+	logger := log.NewLogger() // TODO: replace v1 logger with v2 logger all around the code
 
 	envRepository := env.NewRepository()
 	exporter := export.NewExporter(command.NewFactory(envRepository), fileutil.NewFileManager())
@@ -233,7 +233,7 @@ func main() {
 	}
 }
 
-func deployHTMLReports(config Config, logger loggerV2.Logger) {
+func deployHTMLReports(config Config, logger log.Logger) {
 	logger.Println()
 	logger.Infof("Deploying html reports...")
 
@@ -265,7 +265,7 @@ func loadSecrets() []string {
 	return values
 }
 
-func exportInstallPages(artifactURLCollection ArtifactURLCollection, config Config, exporter export.Exporter, logger loggerV2.Logger) error {
+func exportInstallPages(artifactURLCollection ArtifactURLCollection, config Config, exporter export.Exporter, logger log.Logger) error {
 	if len(artifactURLCollection.PublicInstallPageURLs) > 0 {
 		pages := mapURLsToInstallPages(artifactURLCollection.PublicInstallPageURLs)
 
@@ -316,7 +316,7 @@ func mapURLsToInstallPages(URLs map[string]string) []PublicInstallPage {
 	return pages
 }
 
-func exportMapEnvironment(templateName string, format string, formatName string, outputKey string, pages []PublicInstallPage, exporter export.Exporter, logger loggerV2.Logger) (string, error) {
+func exportMapEnvironment(templateName string, format string, formatName string, outputKey string, pages []PublicInstallPage, exporter export.Exporter, logger log.Logger) (string, error) {
 	var maxEnvLength int
 
 	if configs, err := envman.GetConfigs(); err != nil {
@@ -361,7 +361,7 @@ func applyTemplateWithMaxSize(temp *template.Template, pages []PublicInstallPage
 	return value, logWarning, nil
 }
 
-func logDeployFiles(files []deployment.DeployableItem, logger loggerV2.Logger) {
+func logDeployFiles(files []deployment.DeployableItem, logger log.Logger) {
 	for _, file := range files {
 		message := fmt.Sprintf("- %s", file.Path)
 
@@ -373,7 +373,7 @@ func logDeployFiles(files []deployment.DeployableItem, logger loggerV2.Logger) {
 	}
 }
 
-func clearDeployFiles(filesToDeploy []string, logger loggerV2.Logger) []string {
+func clearDeployFiles(filesToDeploy []string, logger log.Logger) []string {
 	var clearedFilesToDeploy []string
 	for _, pth := range filesToDeploy {
 		_, err := os.Stat(pth)
@@ -393,7 +393,7 @@ func clearDeployFiles(filesToDeploy []string, logger loggerV2.Logger) []string {
 	return clearedFilesToDeploy
 }
 
-func collectFilesToDeploy(absDeployPth string, config Config, tmpDir string, zipManager *ziputil.ZipManager, pathChecker pathutil.PathChecker, logger loggerV2.Logger) (filesToDeploy []string, err error) {
+func collectFilesToDeploy(absDeployPth string, config Config, tmpDir string, zipManager *ziputil.ZipManager, pathChecker pathutil.PathChecker, logger log.Logger) (filesToDeploy []string, err error) {
 	pathExists, err := pathChecker.IsPathExists(absDeployPth)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if %s exists: %s", absDeployPth, err)
@@ -464,7 +464,7 @@ func stepNameWithIndex(stepInfo models.TestResultStepInfo) string {
 	return fmt.Sprintf("%d. Step (%s)", stepInfo.Number, name)
 }
 
-func deployTestResults(config Config, pathChecker pathutil.PathChecker, pathModifier pathutil.PathModifier, logger loggerV2.Logger) {
+func deployTestResults(config Config, pathChecker pathutil.PathChecker, pathModifier pathutil.PathModifier, logger log.Logger) {
 	logger.Println()
 	logger.Infof("Collecting test results...")
 	testResults, err := test.ParseTestResults(config.TestDeployDir, config.UseLegacyXCResultExtractionMethod, pathChecker, pathModifier, logger)
@@ -514,7 +514,7 @@ func findAPKsAndAABs(items []deployment.DeployableItem) (apks []deployment.Deplo
 	return
 }
 
-func deploy(deployableItems []deployment.DeployableItem, config Config, logger loggerV2.Logger) (ArtifactURLCollection, []error) {
+func deploy(deployableItems []deployment.DeployableItem, config Config, logger log.Logger) (ArtifactURLCollection, []error) {
 	apks, aabs, others := findAPKsAndAABs(deployableItems)
 
 	var androidArtifacts []string
@@ -581,7 +581,7 @@ func deploy(deployableItems []deployment.DeployableItem, config Config, logger l
 	return artifactURLCollection, errorCollection
 }
 
-func deploySingleItem(logger loggerV2.Logger, uploader *uploaders.Uploader, item deployment.DeployableItem, config Config, androidArtifacts []string) ([]uploaders.ArtifactURLs, error) {
+func deploySingleItem(logger log.Logger, uploader *uploaders.Uploader, item deployment.DeployableItem, config Config, androidArtifacts []string) ([]uploaders.ArtifactURLs, error) {
 	pth := item.Path
 	fileType := getFileType(pth)
 
@@ -616,7 +616,7 @@ func deploySingleItem(logger loggerV2.Logger, uploader *uploaders.Uploader, item
 	}
 }
 
-func handleDeploymentFailureError(err error, errorCollection []error, logger loggerV2.Logger) []error {
+func handleDeploymentFailureError(err error, errorCollection []error, logger log.Logger) []error {
 	logger.Errorf("%s", errorutil.FormattedError(err))
 	err = fmt.Errorf("deploy failed, error: %w", err)
 	errorCollection = append(errorCollection, err)
@@ -676,7 +676,7 @@ func determineConcurrency(config Config) int {
 	return parseConcurrency(config.UploadConcurrency, defaultUploadConcurrency)
 }
 
-func validateUserGroups(userGroupsStr string, logger loggerV2.Logger) error {
+func validateUserGroups(userGroupsStr string, logger log.Logger) error {
 	if userGroupsStr == "" {
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/bitrise-io/go-steputils/v2/export"
 	"github.com/bitrise-io/go-steputils/v2/secretkeys"
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/errorutil"
@@ -120,7 +119,6 @@ func main() {
 
 	stepconf.Print(config)
 
-	log.SetEnableDebugLog(config.DebugMode)
 	logger.EnableDebugLog(config.DebugMode)
 
 	if err := validateUserGroups(config.NotifyUserGroups, logger); err != nil {
@@ -189,9 +187,9 @@ func main() {
 	}
 
 	if strings.TrimSpace(config.PipelineIntermediateFiles) != "" {
-		zipComparator := deployment.NewZipComparator(deployment.DefaultReadZipFunction)
+		zipComparator := deployment.NewZipComparator(deployment.DefaultReadZipFunction, logger)
 		repository := env.NewRepository()
-		collector := deployment.NewCollector(zipComparator, deployment.DefaultIsDirFunction, zipManager.ZipDir, repository, tmpDir)
+		collector := deployment.NewCollector(zipComparator, deployment.DefaultIsDirFunction, zipManager.ZipDir, repository, tmpDir, logger)
 		deployableItems, err = collector.AddIntermediateFiles(deployableItems, config.PipelineIntermediateFiles)
 		if err != nil {
 			fail(logger, "%s", err)
@@ -296,13 +294,13 @@ func exportInstallPages(artifactURLCollection ArtifactURLCollection, config Conf
 		if err := exporter.ExportOutput("BITRISE_ARTIFACT_DETAILS_PAGE_URL", pages[0].URL); err != nil {
 			return fmt.Errorf("failed to export BITRISE_ARTIFACT_DETAILS_PAGE_URL: %s", err)
 		}
-		log.Printf("The artifact details page url is now available in the Environment Variable: BITRISE_ARTIFACT_DETAILS_PAGE_URL (value: %s)\n", pages[0].URL)
+		logger.Printf("The artifact details page url is now available in the Environment Variable: BITRISE_ARTIFACT_DETAILS_PAGE_URL (value: %s)\n", pages[0].URL)
 
 		value, err := exportMapEnvironment("Details Page URL template", config.DetailsPageURLMapFormat, "DetailsPageURLMap", "BITRISE_ARTIFACT_DETAILS_PAGE_URL_MAP", pages, exporter, logger)
 		if err != nil {
 			return fmt.Errorf("failed to export BITRISE_ARTIFACT_DETAILS_PAGE_URL_MAP, error: %s", err)
 		}
-		log.Printf("A map of deployed files and their details page urls is now available in the Environment Variable: BITRISE_ARTIFACT_DETAILS_PAGE_URL_MAP (value: %s)", value)
+		logger.Printf("A map of deployed files and their details page urls is now available in the Environment Variable: BITRISE_ARTIFACT_DETAILS_PAGE_URL_MAP (value: %s)", value)
 	}
 	return nil
 }

--- a/report/api/api.go
+++ b/report/api/api.go
@@ -88,7 +88,7 @@ func (t *TestReportClient) UploadAsset(url, path, contentType string) error {
 		Path:     path,
 		FileSize: fileInfo.Size(),
 	}
-	_, err = uploaders.UploadArtifact(url, artifact, contentType)
+	_, err = uploaders.UploadArtifact(url, artifact, contentType, t.logger)
 	return err
 }
 

--- a/test/converters_test.go
+++ b/test/converters_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-steputils/v2/testreport"
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-xcode/v2/testresult/xcresult3"
@@ -21,7 +20,6 @@ const sampleArtifactsGitURL = "https://github.com/bitrise-io/sample-artifacts.gi
 func TestXCresult3Converters(t *testing.T) {
 	// xcresulttool renders attachment timestamps in the process timezone; the expected reports are UTC.
 	t.Setenv("TZ", "UTC")
-	log.SetEnableDebugLog(true)
 	want := testreport.TestReport{
 		TestSuites: []testreport.TestSuite{
 			{ // unit test

--- a/uploaders/common_test.go
+++ b/uploaders/common_test.go
@@ -101,7 +101,7 @@ func Test_uploadArtifact(t *testing.T) {
 				Path:     tt.artifactPth,
 				FileSize: fileInfo.Size(),
 			}
-			if _, err := UploadArtifact(tt.uploadURL, artifact, tt.contentType); (err != nil) != tt.wantErr {
+			if _, err := UploadArtifact(tt.uploadURL, artifact, tt.contentType, logV2.NewLogger()); (err != nil) != tt.wantErr {
 				t.Errorf("UploadArtifact() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/uploaders/common_test.go
+++ b/uploaders/common_test.go
@@ -101,7 +101,7 @@ func Test_uploadArtifact(t *testing.T) {
 				Path:     tt.artifactPth,
 				FileSize: fileInfo.Size(),
 			}
-			if _, err := UploadArtifact(tt.uploadURL, artifact, tt.contentType, logV2.NewLogger()); (err != nil) != tt.wantErr {
+			if _, err := UploadArtifact(tt.uploadURL, artifact, tt.contentType, log.NewLogger()); (err != nil) != tt.wantErr {
 				t.Errorf("UploadArtifact() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/uploaders/fileuploader.go
+++ b/uploaders/fileuploader.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	logV2 "github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
 
@@ -58,7 +58,7 @@ func (u *Uploader) DeployFile(item deployment.DeployableItem, buildURL, token st
 }
 
 // createSnapshot copies a file to a temporary directory with the same file name.
-func createSnapshot(originalPath string, logger logV2.Logger) (string, error) {
+func createSnapshot(originalPath string, logger log.Logger) (string, error) {
 	originalFile, err := os.Open(originalPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open original file: %w", err)

--- a/uploaders/fileuploader.go
+++ b/uploaders/fileuploader.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bitrise-io/go-utils/log"
+	logV2 "github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
 
@@ -24,7 +24,7 @@ func (u *Uploader) DeployFile(item deployment.DeployableItem, buildURL, token st
 	//  which can cause an issue like: request body larger than specified content length at file upload.
 	deploySnapshot := false
 	if fileSize <= snapshotFileSizeLimitInBytes {
-		snapshotPth, err := createSnapshot(pth)
+		snapshotPth, err := createSnapshot(pth, u.logger)
 		if err != nil {
 			u.logger.Warnf("failed to create snapshot of %s: %s", pth, err)
 		} else {
@@ -58,14 +58,14 @@ func (u *Uploader) DeployFile(item deployment.DeployableItem, buildURL, token st
 }
 
 // createSnapshot copies a file to a temporary directory with the same file name.
-func createSnapshot(originalPath string) (string, error) {
+func createSnapshot(originalPath string, logger logV2.Logger) (string, error) {
 	originalFile, err := os.Open(originalPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open original file: %w", err)
 	}
 	defer func() {
 		if err := originalFile.Close(); err != nil {
-			log.Warnf("Failed to close original file: %s", err)
+			logger.Warnf("Failed to close original file: %s", err)
 		}
 	}()
 
@@ -81,7 +81,7 @@ func createSnapshot(originalPath string) (string, error) {
 	}
 	defer func() {
 		if err := tmpFile.Close(); err != nil {
-			log.Warnf("Failed to close temp file: %s", err)
+			logger.Warnf("Failed to close temp file: %s", err)
 		}
 	}()
 

--- a/uploaders/upload_multipart.go
+++ b/uploaders/upload_multipart.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/docker/go-units"
 
-	logV2 "github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/bitrise-io/go-utils/v2/urlutil"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
@@ -95,7 +95,7 @@ func (u *Uploader) uploadMultipart(buildURL, token string, artifact ArtifactArgs
 	return artifactURLs, nil
 }
 
-func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger logV2.Logger) ([]MultipartUploadTask, error) {
+func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger log.Logger) ([]MultipartUploadTask, error) {
 	artifactName := filepath.Base(artifact.Path)
 
 	logger.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
@@ -207,7 +207,7 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 	return uploadTasks, nil
 }
 
-func finishMultipartArtifact(buildURL, token, artifactID string, success bool, parts []UploadedPart, appDeploymentMeta *AppDeploymentMetaData, logger logV2.Logger) (ArtifactURLs, error) {
+func finishMultipartArtifact(buildURL, token, artifactID string, success bool, parts []UploadedPart, appDeploymentMeta *AppDeploymentMetaData, logger log.Logger) (ArtifactURLs, error) {
 	data := url.Values{
 		"api_token": {token},
 		"success":   {strconv.FormatBool(success)},
@@ -340,7 +340,7 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 // uploadPart uploads a single chunk of a file to a presigned S3 part URL.
 // It opens the file independently to allow concurrent calls without seeking conflicts.
 // Returns the ETag header value which must be included in the finish call.
-func uploadPart(partURL, filePath string, offset, size int64, partNumber int, logger logV2.Logger) (string, error) {
+func uploadPart(partURL, filePath string, offset, size int64, partNumber int, logger log.Logger) (string, error) {
 	netClient := &http.Client{Timeout: 10 * time.Minute}
 
 	var etag string
@@ -408,7 +408,7 @@ func uploadPart(partURL, filePath string, offset, size int64, partNumber int, lo
 // uploadAllParts uploads the file in partSize-byte chunks, one per partURL, up to
 // concurrency parts at a time. The last part is trimmed to the file's
 // remaining bytes. Returns the ETags required by the finish call.
-func uploadAllParts(filePath string, fileSize int64, partSize int64, partURLs []string, concurrency int, logger logV2.Logger) ([]UploadedPart, error) {
+func uploadAllParts(filePath string, fileSize int64, partSize int64, partURLs []string, concurrency int, logger log.Logger) ([]UploadedPart, error) {
 	if partSize <= 0 {
 		return nil, fmt.Errorf("invalid part size %d", partSize)
 	}

--- a/uploaders/upload_multipart.go
+++ b/uploaders/upload_multipart.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/docker/go-units"
 
-	"github.com/bitrise-io/go-utils/log"
 	logV2 "github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/bitrise-io/go-utils/v2/urlutil"
@@ -99,7 +98,7 @@ func (u *Uploader) uploadMultipart(buildURL, token string, artifact ArtifactArgs
 func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger logV2.Logger) ([]MultipartUploadTask, error) {
 	artifactName := filepath.Base(artifact.Path)
 
-	log.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
+	logger.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
 
 	if strings.TrimSpace(token) == "" {
 		return nil, fmt.Errorf("provided API token is empty")
@@ -137,7 +136,7 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 
 	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
+			logger.Warnf("%d attempt failed", attempt)
 		}
 
 		req, err := http.NewRequest(http.MethodPost, uri, strings.NewReader(data.Encode()))
@@ -157,7 +156,7 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 
 		defer func() {
 			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
+				logger.Errorf("Failed to close reponse body, error: %s", err)
 			}
 		}()
 
@@ -282,7 +281,7 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 	var artifactResponse finishArtifactResponse
 	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
+			logger.Warnf("%d attempt failed", attempt)
 		}
 
 		req, err := http.NewRequest(http.MethodPost, uri, strings.NewReader(encodedBody))
@@ -301,7 +300,7 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 		}
 		defer func() {
 			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
+				logger.Errorf("Failed to close reponse body, error: %s", err)
 			}
 		}()
 
@@ -328,7 +327,7 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 	}
 
 	if len(artifactResponse.InvalidEmails) > 0 {
-		log.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
+		logger.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
 	}
 
 	return ArtifactURLs{
@@ -348,7 +347,7 @@ func uploadPart(partURL, filePath string, offset, size int64, partNumber int, lo
 
 	err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
-			log.Warnf("part %d: attempt %d failed, retrying", partNumber, attempt)
+			logger.Warnf("part %d: attempt %d failed, retrying", partNumber, attempt)
 		}
 
 		file, err := os.Open(filePath)
@@ -357,7 +356,7 @@ func uploadPart(partURL, filePath string, offset, size int64, partNumber int, lo
 		}
 		defer func() {
 			if err := file.Close(); err != nil {
-				log.Warnf("failed to close file: %s", err)
+				logger.Warnf("failed to close file: %s", err)
 			}
 		}()
 
@@ -379,7 +378,7 @@ func uploadPart(partURL, filePath string, offset, size int64, partNumber int, lo
 		}
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				log.Errorf("Failed to close response body, error: %s", err)
+				logger.Errorf("Failed to close response body, error: %s", err)
 			}
 		}()
 

--- a/uploaders/upload_single.go
+++ b/uploaders/upload_single.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/docker/go-units"
 
-	"github.com/bitrise-io/go-utils/log"
+	logV2 "github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/bitrise-io/go-utils/v2/urlutil"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
@@ -34,7 +34,7 @@ func (u UploadTask) Identifier() string {
 }
 
 func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, item *deployment.DeployableItem, buildArtifactMeta *AppDeploymentMetaData) ([]ArtifactURLs, error) {
-	tasks, err := createArtifact(buildURL, token, artifact, artifactType, contentType, item.ArchiveAsArtifact, item.IntermediateFileMeta)
+	tasks, err := createArtifact(buildURL, token, artifact, artifactType, contentType, item.ArchiveAsArtifact, item.IntermediateFileMeta, u.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create artifact (%s): %w", artifact.Path, err)
 	}
@@ -48,7 +48,7 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 
 	var artifactURLs []ArtifactURLs
 	for _, task := range tasks {
-		details, uploadErr := UploadArtifact(task.URL, artifact, contentType)
+		details, uploadErr := UploadArtifact(task.URL, artifact, contentType, u.logger)
 
 		transferType := Artifact
 		if task.IsIntermediate {
@@ -60,7 +60,7 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 			return nil, fmt.Errorf("failed to upload artifact (%s): %w", artifact.Path, uploadErr)
 		}
 
-		urls, err := finishArtifact(buildURL, token, task.Identifier(), buildArtifactMeta)
+		urls, err := finishArtifact(buildURL, token, task.Identifier(), buildArtifactMeta, u.logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to finish artifact upload (%s): %w", artifact.Path, err)
 		}
@@ -73,11 +73,11 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 	return artifactURLs, nil
 }
 
-func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData) ([]UploadTask, error) {
+func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger logV2.Logger) ([]UploadTask, error) {
 	// create form data
 	artifactName := filepath.Base(artifact.Path)
 
-	log.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
+	logger.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
 
 	if strings.TrimSpace(token) == "" {
 		return nil, fmt.Errorf("provided API token is empty")
@@ -114,7 +114,7 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 
 	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
+			logger.Warnf("%d attempt failed", attempt)
 		}
 		response, err = http.PostForm(uri, data)
 		if err != nil {
@@ -123,7 +123,7 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 
 		defer func() {
 			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
+				logger.Errorf("Failed to close reponse body, error: %s", err)
 			}
 		}()
 
@@ -173,7 +173,7 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 	return uploadTasks, nil
 }
 
-func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string) (TransferDetails, error) {
+func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string, logger logV2.Logger) (TransferDetails, error) {
 	netClient := &http.Client{
 		Timeout: 10 * time.Minute,
 	}
@@ -187,7 +187,7 @@ func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string)
 		}
 		defer func() {
 			if err := file.Close(); err != nil {
-				log.Warnf("failed to close file, error: %s", err)
+				logger.Warnf("failed to close file, error: %s", err)
 			}
 		}()
 
@@ -220,7 +220,7 @@ func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string)
 
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				log.Errorf("Failed to close response body, error: %s", err)
+				logger.Errorf("Failed to close response body, error: %s", err)
 			}
 		}()
 
@@ -245,7 +245,7 @@ func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string)
 	return details, err
 }
 
-func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDeploymentMetaData) (ArtifactURLs, error) {
+func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDeploymentMetaData, logger logV2.Logger) (ArtifactURLs, error) {
 	// create form data
 	data := url.Values{"api_token": {token}}
 	if appDeploymentMeta != nil {
@@ -300,7 +300,7 @@ func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDe
 	var artifactResponse finishArtifactResponse
 	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
+			logger.Warnf("%d attempt failed", attempt)
 		}
 		response, err = http.PostForm(uri, data)
 		if err != nil {
@@ -308,7 +308,7 @@ func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDe
 		}
 		defer func() {
 			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
+				logger.Errorf("Failed to close reponse body, error: %s", err)
 			}
 		}()
 
@@ -331,7 +331,7 @@ func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDe
 	}
 
 	if len(artifactResponse.InvalidEmails) > 0 {
-		log.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
+		logger.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
 	}
 
 	return ArtifactURLs{

--- a/uploaders/upload_single.go
+++ b/uploaders/upload_single.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/docker/go-units"
 
-	logV2 "github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/bitrise-io/go-utils/v2/urlutil"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
@@ -73,7 +73,7 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 	return artifactURLs, nil
 }
 
-func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger logV2.Logger) ([]UploadTask, error) {
+func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger log.Logger) ([]UploadTask, error) {
 	// create form data
 	artifactName := filepath.Base(artifact.Path)
 
@@ -173,7 +173,7 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 	return uploadTasks, nil
 }
 
-func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string, logger logV2.Logger) (TransferDetails, error) {
+func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string, logger log.Logger) (TransferDetails, error) {
 	netClient := &http.Client{
 		Timeout: 10 * time.Minute,
 	}
@@ -245,7 +245,7 @@ func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string,
 	return details, err
 }
 
-func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDeploymentMetaData, logger logV2.Logger) (ArtifactURLs, error) {
+func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDeploymentMetaData, logger log.Logger) (ArtifactURLs, error) {
 	// create form data
 	data := url.Values{"api_token": {token}}
 	if appDeploymentMeta != nil {


### PR DESCRIPTION
Stacked on top of #270. Review/merge that first.

## What

Thread a v2 `log.Logger` through the `uploaders` and `deployment` packages, replacing the v1 `go-utils/log` package-level functions with logger instances:

- **uploaders**: `createArtifact`, `UploadArtifact`, `finishArtifact` and `createSnapshot` now take a `logger` (the multipart helpers already did). Callers and tests updated.
- **deployment**: `Collector` and `ZipComparator` gain a `logger` field wired through their constructors (`NewCollector` / `NewZipComparator`); `main.go` and the deployment tests pass it in.
- **main.go**: drops the redundant v1 `SetEnableDebugLog` call (the v2 `EnableDebugLog` was already there) and switches the remaining `log.Printf` calls to the injected logger.

## Not in scope

The `androidartifact.Logger` adaptor in `uploaders/logger.go` still uses the v1 `log` package for its `RWarnf`-based APK/AAB parse warnings, so `go-utils` v1 stays in `go.mod` for now. That is migrated in the follow-up PR.

## Testing

`go build ./...`, `go vet ./...` (only the pre-existing `t.Fatal`-from-goroutine warnings remain) and `go test ./...` all pass.