### PR TITLE
Remove RWarnf parse-warning telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/bitrise-io/envman v0.0.0-20220401145857-d11e00a5dc55
 	github.com/bitrise-io/go-android/v2 v2.0.0-alpha.15
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.52
-	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.38
 	github.com/bitrise-io/go-xcode v1.3.3
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.80
@@ -23,6 +22,7 @@ require (
 	github.com/avast/apkparser v0.0.0-20250626104540-d53391f4d69d // indirect
 	github.com/bitrise-io/go-pkcs12 v0.1.0 // indirect
 	github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 // indirect
+	github.com/bitrise-io/go-utils v1.0.15 // indirect
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4 // indirect
 	github.com/bitrise-io/stepman v0.0.0-20220808095634-6e12d2726f30 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/main.go
+++ b/main.go
@@ -548,7 +548,7 @@ func deploy(deployableItems []deployment.DeployableItem, config Config, logger l
 	uploader := uploaders.New(
 		logger,
 		fileManager,
-		androidparser.New(uploaders.NewLogger(), bTool, fileManager),
+		androidparser.New(uploaders.NewLogger(logger), bTool, fileManager),
 		iosparser.New(logger, fileManager),
 		config.UseMultipartUpload == "true",
 		determineMultipartConcurrency(config),

--- a/uploaders/logger.go
+++ b/uploaders/logger.go
@@ -1,31 +1,24 @@
 package uploaders
 
 import (
-	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-type logger struct{}
-
-func NewLogger() *logger {
-	return &logger{}
+type metaparserLogger struct {
+	logger log.Logger
 }
 
-func (l *logger) Printf(format string, v ...interface{}) {
-	log.Printf(format, v...)
+func NewLogger(logger log.Logger) *metaparserLogger {
+	return &metaparserLogger{logger: logger}
 }
 
-func (l *logger) Errorf(format string, v ...interface{}) {
-	log.Errorf(format, v...)
+func (l *metaparserLogger) Warnf(format string, v ...interface{}) {
+	l.logger.Warnf(format, v...)
 }
 
-func (l *logger) Warnf(format string, v ...interface{}) {
-	log.Warnf(format, v...)
-}
+// AABParseWarnf and APKParseWarnf are telemetry hooks the metaparser calls on
+// parse failures. The step does not collect this telemetry, and the failures
+// are already surfaced to the user via Warnf, so these are intentionally no-ops.
+func (l *metaparserLogger) AABParseWarnf(_ string, _ string, _ ...interface{}) {}
 
-func (l *logger) AABParseWarnf(tag string, format string, v ...interface{}) {
-	log.RWarnf("deploy-to-bitrise-io", tag, nil, format, v...)
-}
-
-func (l *logger) APKParseWarnf(tag string, format string, v ...interface{}) {
-	log.RWarnf("deploy-to-bitrise-io", tag, nil, format, v...)
-}
+func (l *metaparserLogger) APKParseWarnf(_ string, _ string, _ ...interface{}) {}


### PR DESCRIPTION
Stacked on top of #271. Review/merge that first.

## What

Removes the APK/AAB parse-warning telemetry instead of migrating it. The v2 `log` package dropped `RWarnf` (the old remote-log channel these warnings used), and the data isn't consumed by anyone (see team discussion), so we drop the collection rather than carry it forward.

The metaparser requires an `androidartifact.Logger` (`Warnf` + `AABParseWarnf` + `APKParseWarnf`), so the adaptor stays, but:
- `Warnf` forwards to the v2 logger as before.
- `AABParseWarnf` / `APKParseWarnf` become no-ops.

No user-facing behaviour changes: every parse failure that triggered a `*ParseWarnf` call is already logged to the user via an adjacent `Warnf` in the metaparser, so nothing is silently swallowed.

## Result

With the v1 `log` package no longer used directly, `go-utils` v1 drops to an `// indirect` dependency (still pulled transitively by `go-steputils/v2/export`).

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` all pass; `go mod tidy` / `go mod vendor` clean.